### PR TITLE
Add softvis3d plugin release 1.1.0

### DIFF
--- a/softvis3d.properties
+++ b/softvis3d.properties
@@ -2,13 +2,19 @@ category=Visualization/Reporting
 description=Provides 3D models
 homepageUrl=http://softvis3d.com
 archivedVersions=0.5.2,0.6.0,0.7.0,0.8.0,0.8.1,0.9.0,1.0
-publicVersions=1.0.1
+publicVersions=1.1.0,1.0.1
 
 defaults.mavenGroupId=de.rinderle.softvis3d
 defaults.mavenArtifactId=softvis3d
 
+1.1.0.description=Plugin is now adapted to the new directory layout concept.
+1.1.0.sqVersions=[7.6,LATEST]
+1.1.0.date=2019-04-30
+1.1.0.changelogUrl=https://github.com/stefanrinderle/softvis3d/releases/tag/softvis3d-1.1.0
+1.1.0.downloadUrl=https://github.com/stefanrinderle/softvis3d/releases/download/softvis3d-1.1.0/sonar-softvis3d-plugin-1.1.0.jar
+
 1.0.1.description=New dashboard features - dark theme and auto reload
-1.0.1.sqVersions=[6.3,LATEST]
+1.0.1.sqVersions=[6.3,7.5]
 1.0.1.date=2017-12-12
 1.0.1.changelogUrl=https://github.com/stefanrinderle/softvis3d/releases/tag/softvis3d-1.0.1
 1.0.1.downloadUrl=https://github.com/stefanrinderle/softvis3d/releases/download/softvis3d-1.0.1/sonar-softvis3d-plugin-1.0.1.jar

--- a/softvis3d.properties
+++ b/softvis3d.properties
@@ -14,7 +14,7 @@ defaults.mavenArtifactId=softvis3d
 1.1.0.downloadUrl=https://github.com/stefanrinderle/softvis3d/releases/download/softvis3d-1.1.0/sonar-softvis3d-plugin-1.1.0.jar
 
 1.0.1.description=New dashboard features - dark theme and auto reload
-1.0.1.sqVersions=[6.3,7.5]
+1.0.1.sqVersions=[6.3,7.7]
 1.0.1.date=2017-12-12
 1.0.1.changelogUrl=https://github.com/stefanrinderle/softvis3d/releases/tag/softvis3d-1.0.1
 1.0.1.downloadUrl=https://github.com/stefanrinderle/softvis3d/releases/download/softvis3d-1.0.1/sonar-softvis3d-plugin-1.0.1.jar

--- a/softvis3d.properties
+++ b/softvis3d.properties
@@ -14,7 +14,7 @@ defaults.mavenArtifactId=softvis3d
 1.1.0.downloadUrl=https://github.com/stefanrinderle/softvis3d/releases/download/softvis3d-1.1.0/sonar-softvis3d-plugin-1.1.0.jar
 
 1.0.1.description=New dashboard features - dark theme and auto reload
-1.0.1.sqVersions=[6.3,7.7]
+1.0.1.sqVersions=[6.3,7.5]
 1.0.1.date=2017-12-12
 1.0.1.changelogUrl=https://github.com/stefanrinderle/softvis3d/releases/tag/softvis3d-1.0.1
 1.0.1.downloadUrl=https://github.com/stefanrinderle/softvis3d/releases/download/softvis3d-1.0.1/sonar-softvis3d-plugin-1.0.1.jar


### PR DESCRIPTION
SoftVis3D-Plugin is now adapted to the new directory layout concept of SonarQube 7.6. Compatibility versions adapted accordingly.