### PR TITLE
release sonar-findbugs 3.11.0 for latest SQ

### DIFF
--- a/findbugs.properties
+++ b/findbugs.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=sonar-findbugs-plugin
 3.11.0.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.0/sonar-findbugs-plugin-3.11.0.jar
 
 3.10.0.description=Use SpotBugs 3.1.11
-3.10.0.sqVersions=[7.6,LATEST]
+3.10.0.sqVersions=[7.6,7.7]
 3.10.0.date=2019-02-10
 3.10.0.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.10.0
 3.10.0.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.10.0/sonar-findbugs-plugin-3.10.0.jar

--- a/findbugs.properties
+++ b/findbugs.properties
@@ -1,10 +1,16 @@
 category=External Analysers
 description=Provide Findbugs rules for analysis of Java projects
-archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2
-publicVersions=3.9.3,3.10.0
+archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.10.0
+publicVersions=3.9.3,3.11.0
 
 defaults.mavenGroupId=org.sonarsource.sonar-findbugs-plugin
 defaults.mavenArtifactId=sonar-findbugs-plugin
+
+3.11.0.description=Use SpotBugs 3.1.12
+3.11.0.sqVersions=[7.6,LATEST]
+3.11.0.date=2019-05-01
+3.11.0.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.11.0
+3.11.0.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.0/sonar-findbugs-plugin-3.11.0.jar
 
 3.10.0.description=Use SpotBugs 3.1.11
 3.10.0.sqVersions=[7.6,LATEST]


### PR DESCRIPTION
This is the latest version that works with SpotBugs 3.1.12.
* [Changelog](https://github.com/spotbugs/sonar-findbugs/releases/tag/3.11.0)
* [Download](https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.0/sonar-findbugs-plugin-3.11.0.jar)
* [SonarCloud](https://sonarcloud.io/dashboard?branch=3.11.0&id=com.github.spotbugs%3Asonar-findbugs-plugin)