### PR TITLE
Update compatability for Azure AD Plugin

### DIFF
--- a/authaad.properties
+++ b/authaad.properties
@@ -9,6 +9,6 @@ defaults.mavenGroupId=org.almrangers.auth.aad
 defaults.mavenArtifactId=sonar-auth-aad-plugin
 
 1.0.description=Initial release
-1.0.sqVersions=[5.4,LATEST]
+1.0.sqVersions=[5.4,7.0]
 1.0.date=2015-03-31
 1.0.downloadUrl=https://github.com/SonarQubeCommunity/sonar-auth-aad/releases/download/1.0/sonar-auth-aad-plugin-1.0.jar


### PR DESCRIPTION
As noted in these places:

- https://community.sonarsource.com/t/rff-azure-active-directory-aad-authentication-plug-in-for-sonarqube-1-1/3117
- https://github.com/hkamel/sonar-auth-aad/issues/40
- https://github.com/hkamel/sonar-auth-aad/issues/45

_v1.0_ of sonar-auth-aad is only compatible up to SonarQube _v7.0_. Due to the unique index (uniq_external_id) being introduced on dbo.users, trying to upgrade from _v6.7_ to _v7.1_ or greater will cause a migration failure.

While a draft release (https://github.com/hkamel/sonar-auth-aad/releases/tag/1.1-RC2) is available to restore compatability, it has not seen an official release.

We should update the compatibility of _v1.0_