### PR TITLE
release sonar-findbugs 3.9.4 for SonarQube LTS

### DIFF
--- a/findbugs.properties
+++ b/findbugs.properties
@@ -1,7 +1,7 @@
 category=External Analysers
 description=Provide Findbugs rules for analysis of Java projects
-archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.10.0
-publicVersions=3.9.3,3.11.0
+archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.9.3,3.10.0
+publicVersions=3.9.4,3.11.0
 
 defaults.mavenGroupId=org.sonarsource.sonar-findbugs-plugin
 defaults.mavenArtifactId=sonar-findbugs-plugin
@@ -17,6 +17,12 @@ defaults.mavenArtifactId=sonar-findbugs-plugin
 3.10.0.date=2019-02-10
 3.10.0.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.10.0
 3.10.0.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.10.0/sonar-findbugs-plugin-3.10.0.jar
+
+3.9.4.description=Use SpotBugs 3.1.12
+3.9.4.sqVersions=[6.7.1,7.5]
+3.9.4.date=2019-05-20
+3.9.4.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.9.4
+3.9.4.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.9.4/sonar-findbugs-plugin-3.9.4.jar
 
 3.9.3.description=Use SpotBugs 3.1.11
 3.9.3.sqVersions=[6.7.1,7.5]


### PR DESCRIPTION
This is the latest version that works with SpotBugs 3.1.12. Unlike 3.11.0, this version supports SonarQube LTS but doesn't work with the latest one.

* [Changelog](https://github.com/spotbugs/sonar-findbugs/releases/tag/3.9.4)
* [Download](https://github.com/spotbugs/sonar-findbugs/releases/download/3.9.4/sonar-findbugs-plugin-3.9.4.jar)
* [SonarCloud](https://sonarcloud.io/dashboard?branch=3.9.4&id=com.github.spotbugs%3Asonar-findbugs-plugin)