### PR TITLE
Release sonar-auth-aad 1.1.0

### DIFF
--- a/authaad.properties
+++ b/authaad.properties
@@ -1,12 +1,18 @@
 name=Azure Active Directory Authentication for SonarQube
 category=Integration
-description=Enables Azure Active Directory (AAD) users to automatically be sign up (a login is created if they don't have one already) and authenticated on a SonarQube server.
-homepageUrl=https://github.com/SonarQubeCommunity/sonar-auth-aad
-publicVersions=1.0
-archivedVersions=
+description=Allows the use of Azure Active Directory as an authentication source for SonarQube.
+homepageUrl=https://github.com/hkamel/sonar-auth-aad
+publicVersions=1.1.0
+archivedVersions=1.0
 
 defaults.mavenGroupId=org.almrangers.auth.aad
 defaults.mavenArtifactId=sonar-auth-aad-plugin
+
+1.1.0.description=Support group sync, national cloud, fix display name for null values, support SQ 7.2 and newer. If upgrading from earlier release, make sure to read the upgrade notes.
+1.1.0.sqVersions=[7.0, LATEST]
+1.1.0.date=2019-05-01
+1.1.0.changelogUrl=https://github.com/hkamel/sonar-auth-aad/releases/tag/1.1
+1.1.0.downloadUrl=https://github.com/hkamel/sonar-auth-aad/releases/download/1.1/sonar-auth-aad-plugin-1.1.jar
 
 1.0.description=Initial release
 1.0.sqVersions=[5.4,7.0]


### PR DESCRIPTION
Update properties file to reference the 1.1.0 version of Azure AD Auth for SonarQube