### PR TITLE
Mention drop of 32-bit support in SonarCFamily v6.0

### DIFF
--- a/cpp.properties
+++ b/cpp.properties
@@ -22,7 +22,7 @@ defaults.mavenArtifactId=sonar-cpp-plugin
 6.1.date=2019-02-22
 6.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10090&version=14820
 
-6.0.description=11 new C++ rules, 3 new Objective-C rules and improved accuracy with new analysis frontend
+6.0.description=11 new C++ rules, 3 new Objective-C rules and improved accuracy with new analysis frontend. Drop of 32-bit support.
 6.0.sqVersions=[6.7,7.6]
 6.0.downloadUrl=https://binaries.sonarsource.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-6.0.0.10816.jar
 6.0.date=2018-12-19


### PR DESCRIPTION
As of SonarCFamily _v6.0_, we no longer support running analysis on a 32-bit machine. There is no Product News for this release where this was described, nor is it clear in the Release Notes.

A few customers have pinged us through Support and, while not upset that 32-bit support was dropped, are upset it was not clear to them before upgrading. I think this little note in the Marketplace could provide us some cover, and warn users in advance of upgrading. 