### PR TITLE
release sonar-findbugs 3.11.1 for latest SQ

### DIFF
--- a/findbugs.properties
+++ b/findbugs.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=sonar-findbugs-plugin
 3.11.1.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.1/sonar-findbugs-plugin-3.11.1.jar
 
 3.11.0.description=Use SpotBugs 3.1.12
-3.11.0.sqVersions=[7.6,LATEST]
+3.11.0.sqVersions=[7.6,7.9]
 3.11.0.date=2019-05-01
 3.11.0.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.11.0
 3.11.0.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.0/sonar-findbugs-plugin-3.11.0.jar

--- a/findbugs.properties
+++ b/findbugs.properties
@@ -6,7 +6,7 @@ publicVersions=3.9.4,3.11.1
 defaults.mavenGroupId=org.sonarsource.sonar-findbugs-plugin
 defaults.mavenArtifactId=sonar-findbugs-plugin
 
-3.11.1.description=Use SpotBugs 3.1.12
+3.11.1.description=Use SpotBugs 3.1.12 and Fix CVE-2019-10173
 3.11.1.sqVersions=[7.6,LATEST]
 3.11.1.date=2019-09-23
 3.11.1.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.11.1

--- a/findbugs.properties
+++ b/findbugs.properties
@@ -1,10 +1,16 @@
 category=External Analysers
 description=Provide Findbugs rules for analysis of Java projects
-archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.9.3,3.10.0
-publicVersions=3.9.4,3.11.0
+archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.9.3,3.10.0,3.11.0
+publicVersions=3.9.4,3.11.1
 
 defaults.mavenGroupId=org.sonarsource.sonar-findbugs-plugin
 defaults.mavenArtifactId=sonar-findbugs-plugin
+
+3.11.1.description=Use SpotBugs 3.1.12
+3.11.1.sqVersions=[7.6,LATEST]
+3.11.1.date=2019-09-23
+3.11.1.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.11.1
+3.11.1.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.1/sonar-findbugs-plugin-3.11.1.jar
 
 3.11.0.description=Use SpotBugs 3.1.12
 3.11.0.sqVersions=[7.6,LATEST]
@@ -42,7 +48,7 @@ defaults.mavenArtifactId=sonar-findbugs-plugin
 3.9.1.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.9.1
 3.9.1.downloadUrl=https://github.com/spotbugs/sonar-findbugs/releases/download/3.9.1/sonar-findbugs-plugin-3.9.1.jar
 
-3.9.0.description=Java 11, SpotBugs 3.1.8 support 
+3.9.0.description=Java 11, SpotBugs 3.1.8 support
 3.9.0.sqVersions=[6.7.1,7.3]
 3.9.0.date=2018-11-21
 3.9.0.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/3.9.0


### PR DESCRIPTION
This is the latest version that works with SpotBugs 3.1.12.
* [Changelog](https://github.com/spotbugs/sonar-findbugs/releases/tag/3.11.1)
* [Download](https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.1/sonar-findbugs-plugin-3.11.1.jar)
* [SonarCloud](https://sonarcloud.io/dashboard?branch=3.11.1&id=com.github.spotbugs%3Asonar-findbugs-plugin)