### PR TITLE
Move 6.7 - 7.8 to private versions

### DIFF
--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -35,25 +35,225 @@ ltsVersion=7.9.2
 7.9.date=2019-07-01
 
 #==================
-4.5.description=SQALE Rating and Technical Debt Ratio, improvement of Coding Rules pages (active severity filter, display of remediation functions, management of manual rules), various other improvements and bug fixes
-4.5.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.zip
-4.5.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11620
-4.5.date=2014-09-29
+7.8.description=Security hotspots highlighted in project overview, PRs and branches, improved data flow navigation, new developer-friendly security report, enhanced portfolio PDF
+7.8.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.8.zip
+7.8.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14939
+7.8.date=2019-06-19
 
-4.5.1.description=Long-Term Support version - Many bug fixes and small improvements
-4.5.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.1.zip
-4.5.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11621
-4.5.1.date=2014-10-29
+7.7.description=Real Quality Gates for pull requests, integration with GitHub Checks, decoration in Bitbucket Server, detection of PHP injection flaws
+7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.7.zip
+7.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14848
+7.7.date=2019-03-20
 
-4.5.2.description=Long-Term Support version - LTS bug fixes
-4.5.2.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.2.zip
-4.5.2.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11622
-4.5.2.date=2015-01-07
+7.6.description=Drop of modules, simplification of Quality Gates, taint detection in collections
+7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.6.zip
+7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14753
+7.6.date=2019-01-28
 
-4.5.4.description=Long-Term Support version - LTS Bug fixes (performance issue with Java 8 on server side, security vulnerabilities), SQALE model update
-4.5.4.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.4.zip
-4.5.4.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11623
-4.5.4.date=2015-02-26
+7.5.description=Scala, Apex, enhanced security reports, duplication metrics in pull requests, support of array for vulnerabilities in Java and C#, new security hotspots, better accuracy for C, C++ and Objective-C analyzers
+7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.5.zip
+7.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14693
+7.5.date=2018-12-20
+
+7.4.description=Ruby and open-sourced VB.NET analysis, import of issues from 3rd-party Roslyn analyzers, security hotspots in Swift, T-SQL, VB.NET and C#, coverage metrics in pull requests, import of JaCoCo XML reports for Kotlin and Java, embedded documentation 
+7.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.4.zip
+7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14549
+7.4.date=2018-10-29
+
+7.3.description=Security Hotspots and Security Reports, Branches in Applications, new Kotlin and CSS analyzers, new rules in Java and PHP plus the import of issues from external Java analyzers
+7.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.3.zip
+7.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14464
+7.3.date=2018-08-13
+
+7.2.1.description=Bug fixes
+7.2.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.2.1.zip
+7.2.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14517
+7.2.1.date=2018-06-29
+
+7.2.description=New per-edition packaging with all features built-in, PR analysis and decoration in GitHub Enterprise and TFS, import of issues from 3rd-party analyzers, detection of the most notorious CWE vulnerabilities in Java and C#
+7.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.2.zip
+7.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14213
+7.2.date=2018-06-18
+
+7.1.description=Homepage selection, project badges, new webhooks console, "New Code" measures without SCM
+7.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.1.zip
+7.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14178
+7.1.date=2018-04-17
+
+7.0.description=Live update of project measures and quality gate status, read-only built-in "Sonar way" quality gate
+7.0.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.0.zip
+7.0.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14041
+7.0.date=2018-02-02
+
+6.7.7.description=Long-Term Support version - LTS bug fixes
+6.7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.7.zip
+6.7.7.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14865
+6.7.7.date=2019-04-17
+
+6.7.6.description=Long-Term Support version - LTS bug fixes
+6.7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.6.zip
+6.7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14621
+6.7.6.date=2018-11-20
+
+6.7.5.description=Long-Term Support version - LTS bug fixes
+6.7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.5.zip
+6.7.5.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14467
+6.7.5.date=2018-08-06
+
+6.7.4.description=Long-Term Support version - LTS bug fixes
+6.7.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.4.zip
+6.7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14377
+6.7.4.date=2018-05-30
+
+6.7.3.description=Long-Term Support version - LTS bug fixes
+6.7.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.3.zip
+6.7.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14264
+6.7.3.date=2018-04-06
+
+6.7.2.description=Long-Term Support version - LTS bug fixes
+6.7.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.2.zip
+6.7.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14191
+6.7.2.date=2018-02-26
+
+6.7.1.description=Long-Term Support version - LTS bug fixes
+6.7.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.1.zip
+6.7.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14137
+6.7.1.date=2017-12-21
+
+6.7.description=Long-Term Support version - Many bug fixes and small improvements
+6.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.zip
+6.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13972
+6.7.date=2017-11-07
+
+6.6.description=New Measures page, new permission "Edit Quality Profile", enhanced "Projects Management" page, notification for failed background tasks, authentication for webhooks, reduce noise related to updated rules, upgrade to Elasticsearch 5, basic telemetry
+6.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.6.zip
+6.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13961
+6.6.date=2017-10-20
+
+6.5.description=Show leak on Projects page, better understand the history of a project with timelines, read-only built-in quality profiles with highlighting on "Sonar way" ones, onboarding for new users
+6.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.5.zip
+6.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13805
+6.5.date=2017-08-03
+
+6.4.description=Tag of projects, enhanced 'Projects' page with more details/filters and with visualisations, efficient UX for issue multiple locations, more usable global search, core support for private/public projects
+6.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.4.zip
+6.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13697
+6.4.date=2017-06-02
+
+6.3.1.description=Bug fixes
+6.3.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.3.1.zip
+6.3.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13767
+6.3.1.date=2017-04-12
+
+6.3.description=Project Activity page, full JS web application with extension points, remove noise on the leak period for newly activated rules, embed SonarPHP and SonarPython and SonarFlex
+6.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.3.zip
+6.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13470
+6.3.date=2017-03-14
+
+6.2.description=New Projects page, enhanced Issues pages, new landing page for non authenticated users, consolidated coverage features, webhooks, authentication by HTTP header, rating support in Quality Gates
+6.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.2.zip
+6.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13327
+6.2.date=2016-12-14
+
+6.1.description=Redesign of the Settings domain with new UI and dedicated WS, improvements on the project home page, first steps towards clustering of SonarQube
+6.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.1.zip
+6.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13287
+6.1.date=2016-10-13
+
+6.0.description=Tracking of file move/renaming, better management of quality profiles and new rules, improvement of permission pages, "Project Creator" feature to enable automatic onboarding for new projects, CSRF fix for Java WS-based pages, Elasticsearch upgrade to 2.x
+6.0.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.0.zip
+6.0.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13026
+6.0.date=2016-08-04
+
+5.6.7.description=Long-Term Support version - LTS Bug fixes
+5.6.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.7.zip
+5.6.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13778
+5.6.7.date=2017-09-25
+
+5.6.6.description=Long-Term Support version - LTS Bug fixes
+5.6.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.6.zip
+5.6.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13718
+5.6.6.date=2017-02-17
+
+5.6.5.description=Long-Term Support version - LTS Bug fixes
+5.6.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.5.zip
+5.6.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13660
+5.6.5.date=2017-01-19
+
+5.6.4.description=Long-Term Support version - LTS Bug fixes
+5.6.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.4.zip
+5.6.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13483
+5.6.4.date=2016-12-12
+
+5.6.3.description=Long-Term Support version - LTS Bug fixes
+5.6.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.3.zip
+5.6.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13420
+5.6.3.date=2016-10-04
+
+5.6.2.description=Long-Term Support version - LTS Bug and vulnerability fixes
+5.6.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.2.zip
+5.6.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13334
+5.6.2.date=2016-09-19
+
+5.6.1.description=Long-Term Support version - LTS Bug and vulnerability fixes
+5.6.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.1.zip
+5.6.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13293
+5.6.1.date=2016-07-27
+
+5.6.description=Long-Term Support version - Many bug fixes and small improvements
+5.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.zip
+5.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12869
+5.6.date=2016-06-01
+
+5.5.description=New SonarQube Quality Model with built-in support of "Bugs" and "Vulnerabilities" issue types, new Measures project page, Compute Engine in a dedicated process, improved Background Tasks page
+5.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.5.zip
+5.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12940
+5.5.date=2016-05-03
+
+5.4.description=New "Code" page, "My Account" space (with token generation), cross-module duplications, new API for Identity providers (OAuth GitHub plugin for instance), restart from the Web console
+5.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.4.zip
+5.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12781
+5.4.date=2016-03-08
+
+5.3.description=New project homepage highlighting Quality Gate and (newly introduced) Leak concepts, cross-project duplication back, access token to run analysis or call WS, WS to implement a build breaker strategy
+5.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.3.zip
+5.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=11647
+5.3.date=2016-01-11
+
+5.2.description=Scanners no longer access the database, new features to efficiently manage issues (more precise location, "My New Issues" notification, technical debt displayed in Issues page, new Issue Filter widget, default assignee per project), enhanced monitoring features, new administration web services, rewrite of global administration pages
+5.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.2.zip
+5.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=11629
+5.2.date=2015-11-02
+
+5.1.2.description=Bug fixes
+5.1.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.1.2.zip
+5.1.2.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=12450
+5.1.2.date=2015-07-27
+
+5.1.1.description=Bug fixes
+5.1.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.1.1.zip
+5.1.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11628
+5.1.1.date=2015-06-05
+
+5.1.description=New overall layout, merge Issues Drilldown with Issues page, tags of issues, auto-assignment of issues, "won't fix" issues, issues report as a core feature, new Rules page, more efficient Component Viewer, possibility to import all files, timezone issue fixed, SonarQube binaries compatible with Java 1.7+ only
+5.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.1.zip
+5.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11627
+5.1.date=2015-04-02
+
+5.0.1.description=Bug fixes, SQALE model update
+5.0.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.0.1.zip
+5.0.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11626
+5.0.1.date=2015-02-24
+
+5.0.description=New Issues page with facets, SCM built-support for Git and SVN, first steps of analysis report processing on server side, end of Maven 2 support, end of "sonar.importSources" support, use of '/' in branch names
+5.0.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.0.zip
+5.0.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11625
+5.0.date=2015-01-14
+
+4.5.7.description=Long-Term Support version - LTS Vulnerability fixes
+4.5.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-4.5.7.zip
+4.5.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13000
+4.5.7.date=2016-04-08
 
 4.5.5.description=Long-Term Support version - LTS Bug fixes
 4.5.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-4.5.5.zip
@@ -65,222 +265,22 @@ ltsVersion=7.9.2
 4.5.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12480
 4.5.6.date=2015-10-16
 
-4.5.7.description=Long-Term Support version - LTS Vulnerability fixes
-4.5.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-4.5.7.zip
-4.5.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13000
-4.5.7.date=2016-04-08
+4.5.4.description=Long-Term Support version - LTS Bug fixes (performance issue with Java 8 on server side, security vulnerabilities), SQALE model update
+4.5.4.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.4.zip
+4.5.4.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11623
+4.5.4.date=2015-02-26
 
-5.0.description=New Issues page with facets, SCM built-support for Git and SVN, first steps of analysis report processing on server side, end of Maven 2 support, end of "sonar.importSources" support, use of '/' in branch names
-5.0.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.0.zip
-5.0.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11625
-5.0.date=2015-01-14
+4.5.2.description=Long-Term Support version - LTS bug fixes
+4.5.2.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.2.zip
+4.5.2.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11622
+4.5.2.date=2015-01-07
 
-5.0.1.description=Bug fixes, SQALE model update
-5.0.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.0.1.zip
-5.0.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11626
-5.0.1.date=2015-02-24
+4.5.1.description=Long-Term Support version - Many bug fixes and small improvements
+4.5.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.1.zip
+4.5.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11621
+4.5.1.date=2014-10-29
 
-5.1.description=New overall layout, merge Issues Drilldown with Issues page, tags of issues, auto-assignment of issues, "won't fix" issues, issues report as a core feature, new Rules page, more efficient Component Viewer, possibility to import all files, timezone issue fixed, SonarQube binaries compatible with Java 1.7+ only
-5.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.1.zip
-5.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11627
-5.1.date=2015-04-02
-
-5.1.1.description=Bug fixes
-5.1.1.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-5.1.1.zip
-5.1.1.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11628
-5.1.1.date=2015-06-05
-
-5.1.2.description=Bug fixes
-5.1.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.1.2.zip
-5.1.2.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=12450
-5.1.2.date=2015-07-27
-
-5.2.description=Scanners no longer access the database, new features to efficiently manage issues (more precise location, "My New Issues" notification, technical debt displayed in Issues page, new Issue Filter widget, default assignee per project), enhanced monitoring features, new administration web services, rewrite of global administration pages
-5.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.2.zip
-5.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=11629
-5.2.date=2015-11-02
-
-5.3.description=New project homepage highlighting Quality Gate and (newly introduced) Leak concepts, cross-project duplication back, access token to run analysis or call WS, WS to implement a build breaker strategy
-5.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.3.zip
-5.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=11647
-5.3.date=2016-01-11
-
-5.4.description=New "Code" page, "My Account" space (with token generation), cross-module duplications, new API for Identity providers (OAuth GitHub plugin for instance), restart from the Web console
-5.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.4.zip
-5.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12781
-5.4.date=2016-03-08
-
-5.5.description=New SonarQube Quality Model with built-in support of "Bugs" and "Vulnerabilities" issue types, new Measures project page, Compute Engine in a dedicated process, improved Background Tasks page
-5.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.5.zip
-5.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12940
-5.5.date=2016-05-03
-
-5.6.description=Long-Term Support version - Many bug fixes and small improvements
-5.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.zip
-5.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=12869
-5.6.date=2016-06-01
-
-5.6.1.description=Long-Term Support version - LTS Bug and vulnerability fixes
-5.6.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.1.zip
-5.6.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13293
-5.6.1.date=2016-07-27
-
-5.6.2.description=Long-Term Support version - LTS Bug and vulnerability fixes
-5.6.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.2.zip
-5.6.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13334
-5.6.2.date=2016-09-19
-
-5.6.3.description=Long-Term Support version - LTS Bug fixes
-5.6.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.3.zip
-5.6.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13420
-5.6.3.date=2016-10-04
-
-5.6.4.description=Long-Term Support version - LTS Bug fixes
-5.6.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.4.zip
-5.6.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13483
-5.6.4.date=2016-12-12
-
-5.6.5.description=Long-Term Support version - LTS Bug fixes
-5.6.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.5.zip
-5.6.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13660
-5.6.5.date=2017-01-19
-
-5.6.6.description=Long-Term Support version - LTS Bug fixes
-5.6.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.6.zip
-5.6.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13718
-5.6.6.date=2017-02-17
-
-5.6.7.description=Long-Term Support version - LTS Bug fixes
-5.6.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-5.6.7.zip
-5.6.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13778
-5.6.7.date=2017-09-25
-
-6.0.description=Tracking of file move/renaming, better management of quality profiles and new rules, improvement of permission pages, "Project Creator" feature to enable automatic onboarding for new projects, CSRF fix for Java WS-based pages, Elasticsearch upgrade to 2.x
-6.0.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.0.zip
-6.0.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13026
-6.0.date=2016-08-04
-
-6.1.description=Redesign of the Settings domain with new UI and dedicated WS, improvements on the project home page, first steps towards clustering of SonarQube
-6.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.1.zip
-6.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13287
-6.1.date=2016-10-13
-
-6.2.description=New Projects page, enhanced Issues pages, new landing page for non authenticated users, consolidated coverage features, webhooks, authentication by HTTP header, rating support in Quality Gates
-6.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.2.zip
-6.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13327
-6.2.date=2016-12-14
-
-6.3.description=Project Activity page, full JS web application with extension points, remove noise on the leak period for newly activated rules, embed SonarPHP and SonarPython and SonarFlex
-6.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.3.zip
-6.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13470
-6.3.date=2017-03-14
-
-6.3.1.description=Bug fixes
-6.3.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.3.1.zip
-6.3.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13767
-6.3.1.date=2017-04-12
-
-6.4.description=Tag of projects, enhanced 'Projects' page with more details/filters and with visualisations, efficient UX for issue multiple locations, more usable global search, core support for private/public projects
-6.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.4.zip
-6.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13697
-6.4.date=2017-06-02
-
-6.5.description=Show leak on Projects page, better understand the history of a project with timelines, read-only built-in quality profiles with highlighting on "Sonar way" ones, onboarding for new users
-6.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.5.zip
-6.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13805
-6.5.date=2017-08-03
-
-6.6.description=New Measures page, new permission "Edit Quality Profile", enhanced "Projects Management" page, notification for failed background tasks, authentication for webhooks, reduce noise related to updated rules, upgrade to Elasticsearch 5, basic telemetry
-6.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.6.zip
-6.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13961
-6.6.date=2017-10-20
-
-6.7.description=Long-Term Support version - Many bug fixes and small improvements
-6.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.zip
-6.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=13972
-6.7.date=2017-11-07
-
-6.7.1.description=Long-Term Support version - LTS bug fixes
-6.7.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.1.zip
-6.7.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14137
-6.7.1.date=2017-12-21
-
-6.7.2.description=Long-Term Support version - LTS bug fixes
-6.7.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.2.zip
-6.7.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14191
-6.7.2.date=2018-02-26
-
-6.7.3.description=Long-Term Support version - LTS bug fixes
-6.7.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.3.zip
-6.7.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14264
-6.7.3.date=2018-04-06
-
-6.7.4.description=Long-Term Support version - LTS bug fixes
-6.7.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.4.zip
-6.7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14377
-6.7.4.date=2018-05-30
-
-6.7.5.description=Long-Term Support version - LTS bug fixes
-6.7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.5.zip
-6.7.5.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14467
-6.7.5.date=2018-08-06
-
-6.7.6.description=Long-Term Support version - LTS bug fixes
-6.7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.6.zip
-6.7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14621
-6.7.6.date=2018-11-20
-
-6.7.7.description=Long-Term Support version - LTS bug fixes
-6.7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.7.zip
-6.7.7.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14865
-6.7.7.date=2019-04-17
-
-7.0.description=Live update of project measures and quality gate status, read-only built-in "Sonar way" quality gate
-7.0.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.0.zip
-7.0.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14041
-7.0.date=2018-02-02
-
-7.1.description=Homepage selection, project badges, new webhooks console, "New Code" measures without SCM
-7.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.1.zip
-7.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14178
-7.1.date=2018-04-17
-
-7.2.description=New per-edition packaging with all features built-in, PR analysis and decoration in GitHub Enterprise and TFS, import of issues from 3rd-party analyzers, detection of the most notorious CWE vulnerabilities in Java and C#
-7.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.2.zip
-7.2.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14213
-7.2.date=2018-06-18
-
-7.2.1.description=Bug fixes
-7.2.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.2.1.zip
-7.2.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14517
-7.2.1.date=2018-06-29
-
-7.3.description=Security Hotspots and Security Reports, Branches in Applications, new Kotlin and CSS analyzers, new rules in Java and PHP plus the import of issues from external Java analyzers
-7.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.3.zip
-7.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14464
-7.3.date=2018-08-13
-
-7.4.description=Ruby and open-sourced VB.NET analysis, import of issues from 3rd-party Roslyn analyzers, security hotspots in Swift, T-SQL, VB.NET and C#, coverage metrics in pull requests, import of JaCoCo XML reports for Kotlin and Java, embedded documentation 
-7.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.4.zip
-7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14549
-7.4.date=2018-10-29
-
-7.5.description=Scala, Apex, enhanced security reports, duplication metrics in pull requests, support of array for vulnerabilities in Java and C#, new security hotspots, better accuracy for C, C++ and Objective-C analyzers
-7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.5.zip
-7.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14693
-7.5.date=2018-12-20
-
-7.6.description=Drop of modules, simplification of Quality Gates, taint detection in collections
-7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.6.zip
-7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14753
-7.6.date=2019-01-28
-
-7.7.description=Real Quality Gates for pull requests, integration with GitHub Checks, decoration in Bitbucket Server, detection of PHP injection flaws
-7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.7.zip
-7.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14848
-7.7.date=2019-03-20
-
-7.8.description=Security hotspots highlighted in project overview, PRs and branches, improved data flow navigation, new developer-friendly security report, enhanced portfolio PDF
-7.8.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.8.zip
-7.8.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14939
-7.8.date=2019-06-19
+4.5.description=SQALE Rating and Technical Debt Ratio, improvement of Coding Rules pages (active severity filter, display of remediation functions, management of manual rules), various other improvements and bug fixes
+4.5.downloadUrl=https://downloads.sonarsource.com/sonarqube/sonarqube-4.5.zip
+4.5.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=11620
+4.5.date=2014-09-29

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,8 +1,8 @@
 plugins=abap,aemrules,android,ansible,sonarapex,apigee,authaad,authbitbucket,authgithub,authgitlab,authgoogleoauth,authoidc,authsaml,branch,checkstyle,citymodel,clover,cnesreport,cobertura,cobol,codecrackercsharp,communitybsl,cpp,crowd,csharp,cssfamily,developer,findbugs,flex,fxcop,github,gitlab,go,governance,groovy,guavamigration,ha,icode,issueresolver,jacoco,java,javai18n,javascript,jdepend,jqassistant,kotlin,ldap,license,lits,l10nde,l10nfr,l10nel,l10nes,l10nit,l10nja,l10nko,l10npt,l10nru,l10nzh,l10nzhtw,lua,mulesoft,mutationanalysis,mybatis,pam,php,pitest,pli,plsql,pmd,python,quboo,shellcheck,status,rci,rpg,ruby,sonarscala,scmcvs,scmgit,scmjazzrtc,scmtfvc,scmmercurial,scmperforce,scmsvn,scmclearcase,smells,softvis3d,Sonargraph,sonargraphintegration,swift,timeline,tsql,typescript,webdriver,vb,vbnet,web,xanitizer,xml,yaml
 
 devVersion=8.2-SNAPSHOT
-publicVersions=6.7,6.7.1,6.7.2,6.7.3,6.7.4,6.7.5,6.7.6,6.7.7,7.0,7.1,7.2,7.2.1,7.3,7.4,7.5,7.6,7.7,7.8,7.9,7.9.1,7.9.2,8.0,8.1
-privateVersions=4.2,4.3,4.3.1,4.3.2,4.3.3,4.4,4.4.1,4.5,4.5.1,4.5.2,4.5.4,4.5.5,4.5.6,4.5.7,5.0,5.0.1,5.1,5.1.1,5.1.2,5.2,5.3,5.4,5.5,5.6,5.6.1,5.6.2,5.6.3,5.6.4,5.6.5,5.6.6,5.6.7,6.0,6.1,6.2,6.3,6.3.1,6.4,6.5,6.6
+publicVersions=7.9,7.9.1,7.9.2,8.0,8.1
+privateVersions=4.2,4.3,4.3.1,4.3.2,4.3.3,4.4,4.4.1,4.5,4.5.1,4.5.2,4.5.4,4.5.5,4.5.6,4.5.7,5.0,5.0.1,5.1,5.1.1,5.1.2,5.2,5.3,5.4,5.5,5.6,5.6.1,5.6.2,5.6.3,5.6.4,5.6.5,5.6.6,5.6.7,6.0,6.1,6.2,6.3,6.3.1,6.4,6.5,6.6,6.7,6.7.1,6.7.2,6.7.3,6.7.4,6.7.5,6.7.6,6.7.7,7.0,7.1,7.2,7.2.1,7.3,7.4,7.5,7.6,7.7,7.8
 
 ltsVersion=7.9.2
 
@@ -33,51 +33,6 @@ ltsVersion=7.9.2
 7.9.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.9.zip
 7.9.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14945
 7.9.date=2019-07-01
-
-7.8.description=Security hotspots highlighted in project overview, PRs and branches, improved data flow navigation, new developer-friendly security report, enhanced portfolio PDF
-7.8.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.8.zip
-7.8.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14939
-7.8.date=2019-06-19
-
-7.7.description=Real Quality Gates for pull requests, integration with GitHub Checks, decoration in Bitbucket Server, detection of PHP injection flaws
-7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.7.zip
-7.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14848
-7.7.date=2019-03-20
-
-7.6.description=Drop of modules, simplification of Quality Gates, taint detection in collections
-7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.6.zip
-7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14753
-7.6.date=2019-01-28
-
-7.5.description=Scala, Apex, enhanced security reports, duplication metrics in pull requests, support of array for vulnerabilities in Java and C#, new security hotspots, better accuracy for C, C++ and Objective-C analyzers
-7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.5.zip
-7.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14693
-7.5.date=2018-12-20
-
-7.4.description=Ruby and open-sourced VB.NET analysis, import of issues from 3rd-party Roslyn analyzers, security hotspots in Swift, T-SQL, VB.NET and C#, coverage metrics in pull requests, import of JaCoCo XML reports for Kotlin and Java, embedded documentation 
-7.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.4.zip
-7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14549
-7.4.date=2018-10-29
-
-7.3.description=Security Hotspots and Security Reports, Branches in Applications, new Kotlin and CSS analyzers, new rules in Java and PHP plus the import of issues from external Java analyzers
-7.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.3.zip
-7.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14464
-7.3.date=2018-08-13
-
-6.7.7.description=Long-Term Support version - LTS bug fixes
-6.7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.7.zip
-6.7.7.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14865
-6.7.7.date=2019-04-17
-
-6.7.6.description=Long-Term Support version - LTS bug fixes
-6.7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.6.zip
-6.7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14621
-6.7.6.date=2018-11-20
-
-6.7.5.description=Long-Term Support version - LTS bug fixes
-6.7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.5.zip
-6.7.5.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14467
-6.7.5.date=2018-08-06
 
 #==================
 4.5.description=SQALE Rating and Technical Debt Ratio, improvement of Coding Rules pages (active severity filter, display of remediation functions, management of manual rules), various other improvements and bug fixes
@@ -265,6 +220,21 @@ ltsVersion=7.9.2
 6.7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14377
 6.7.4.date=2018-05-30
 
+6.7.5.description=Long-Term Support version - LTS bug fixes
+6.7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.5.zip
+6.7.5.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14467
+6.7.5.date=2018-08-06
+
+6.7.6.description=Long-Term Support version - LTS bug fixes
+6.7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.6.zip
+6.7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14621
+6.7.6.date=2018-11-20
+
+6.7.7.description=Long-Term Support version - LTS bug fixes
+6.7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.7.zip
+6.7.7.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14865
+6.7.7.date=2019-04-17
+
 7.0.description=Live update of project measures and quality gate status, read-only built-in "Sonar way" quality gate
 7.0.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.0.zip
 7.0.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14041
@@ -284,3 +254,33 @@ ltsVersion=7.9.2
 7.2.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.2.1.zip
 7.2.1.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14517
 7.2.1.date=2018-06-29
+
+7.3.description=Security Hotspots and Security Reports, Branches in Applications, new Kotlin and CSS analyzers, new rules in Java and PHP plus the import of issues from external Java analyzers
+7.3.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.3.zip
+7.3.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14464
+7.3.date=2018-08-13
+
+7.4.description=Ruby and open-sourced VB.NET analysis, import of issues from 3rd-party Roslyn analyzers, security hotspots in Swift, T-SQL, VB.NET and C#, coverage metrics in pull requests, import of JaCoCo XML reports for Kotlin and Java, embedded documentation 
+7.4.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.4.zip
+7.4.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14549
+7.4.date=2018-10-29
+
+7.5.description=Scala, Apex, enhanced security reports, duplication metrics in pull requests, support of array for vulnerabilities in Java and C#, new security hotspots, better accuracy for C, C++ and Objective-C analyzers
+7.5.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.5.zip
+7.5.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14693
+7.5.date=2018-12-20
+
+7.6.description=Drop of modules, simplification of Quality Gates, taint detection in collections
+7.6.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.6.zip
+7.6.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14753
+7.6.date=2019-01-28
+
+7.7.description=Real Quality Gates for pull requests, integration with GitHub Checks, decoration in Bitbucket Server, detection of PHP injection flaws
+7.7.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.7.zip
+7.7.changelogUrl=https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14848
+7.7.date=2019-03-20
+
+7.8.description=Security hotspots highlighted in project overview, PRs and branches, improved data flow navigation, new developer-friendly security report, enhanced portfolio PDF
+7.8.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.8.zip
+7.8.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=14939
+7.8.date=2019-06-19


### PR DESCRIPTION
SonarQube 6.7 through 7.8 are all considered EOL now that six months have passed since the new LTS was released.

Services Team discussed this and we are fully comfortable with this since no plugin updates have been released for 6.7 - 7.8 since the new LTS was released in July.