### PR TITLE
Update sonar-dependency-check-plugin to 2.0.3

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,13 +1,19 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=
-publicVersions=2.0.2
+archivedVersions=2.0.2
+publicVersions=2.0.3
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
+2.0.3.description=Integrates Dependency-Check reports into SonarQube
+2.0.3.sqVersions=[7.9, LATEST]
+2.0.3.date=2020-03-07
+2.0.3.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.3
+2.0.3.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.3/sonar-dependency-check-plugin-2.0.3.jar
+
 2.0.2.description=Integrates Dependency-Check reports into SonarQube
-2.0.2.sqVersions=[7.9, LATEST]
+2.0.2.sqVersions=[7.9, 8.2]
 2.0.2.date=2020-01-28
 2.0.2.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.2
 2.0.2.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.2/sonar-dependency-check-plugin-2.0.2.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 2.0.3, please add it to the marketplace.
Thanks in advance!