### PR TITLE
Release: AEMRules v1.1 fix Jar link in metadata

### DIFF
--- a/aemrules.properties
+++ b/aemrules.properties
@@ -11,7 +11,7 @@ defaults.mavenArtifactId=sonar-aemrules-plugin
 1.1.sqVersions=[7.9,LATEST]
 1.1.date=2020-04-02
 1.1.changelogUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/tag/v1.1
-1.1.downloadUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/download/v1.0/sonar-aemrules-plugin-1.0.jar
+1.1.downloadUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/download/v1.1/sonar-aemrules-plugin-1.1.jar
 
 1.0.description=HTL Support
 1.0.sqVersions=[7.9,8.2]


### PR DESCRIPTION
It appears https://github.com/SonarSource/sonar-update-center-properties/pull/112 came through with an erroneous link to the 1.1 binary

When viewed in the Marketplace, the plugin comes up as v1.0 and links to v1.1 docs. I belive this link to be the reason for that.

![aem_rules_version_mismatch](https://user-images.githubusercontent.com/8336085/78894497-6dc6f200-7a6d-11ea-9053-5928e060a0e9.png)

This PR aims to amend that. Please confirm if there's anywhere else the wrong metadata could be coming from.
