### PR TITLE
Add icode plugin 2.0.2

### DIFF
--- a/icode.properties
+++ b/icode.properties
@@ -1,13 +1,19 @@
-category=External Analyzers
-description=Analyze your Fortran(77 & 90) and Shell code with i-Code CNES
+category=Languages
+description=Code Analyzer for Fortran(77 & 90) and Shell (using i-Code CNES)
 homepageUrl=https://github.com/lequal/sonar-icode-cnes-plugin
-archivedVersions=1.0.2,1.1.0
-publicVersions=2.0.1
+archivedVersions=1.0.2,1.1.0,2.0.1
+publicVersions=2.0.2
 
 sonar.pluginKey=icode
 
 defaults.mavenGroupId=fr.cnes.sonarqube.plugins
 defaults.mavenArtifactId=sonar-icode-cnes-plugin
+
+2.0.2.description=Analyze Fortran and Shell on SonarQube 7.9 and 8
+2.0.2.date=2020-04-08
+2.0.2.sqVersions=[7.9,LATEST]
+2.0.2.changelogUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/tag/2.0.2
+2.0.2.downloadUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/2.0.2/sonar-icode-cnes-plugin-2.0.2.jar
 
 2.0.1.description=i-Code CNES is now embedded in the plugin, no more need to install it
 2.0.1.date=2020-02-14


### PR DESCRIPTION
Add new version 2.0.2 of I-Code CNES plugin an change category from **External Analyzers** to **Languages**.

#### Fixed bugs
- [x] **BUG #55** > SonarQube analysis crashes when i-Code crashes
- [x] **BUG #59** > JAXB is still used in the plugin
- [x] **BUG #60** > Dead links on the README