### PR TITLE
Update dependency-check-sonar-plugin to 2.0.5

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,13 +1,19 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.2,2.0.3
-publicVersions=2.0.4
+archivedVersions=2.0.2,2.0.3,2.0.4
+publicVersions=2.0.5
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
+2.0.5.description=Ability to use security hotspot feature. Marking of issues improved based on dependency language.
+2.0.5.sqVersions=[7.9, LATEST]
+2.0.5.date=2020-06-10
+2.0.5.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.5
+2.0.5.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.5/sonar-dependency-check-plugin-2.0.5.jar
+
 2.0.4.description=Parse Dependency-Check exceptions and rewrite HTML report view in SonarQube
-2.0.4.sqVersions=[7.9, LATEST]
+2.0.4.sqVersions=[7.9, 8.3]
 2.0.4.date=2020-03-26
 2.0.4.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.4
 2.0.4.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.4/sonar-dependency-check-plugin-2.0.4.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 2.0.5, please add it to the marketplace.
Thanks in advance!