### PR TITLE
Change lequal to cnescatlab

### DIFF
--- a/cnesreport.properties
+++ b/cnesreport.properties
@@ -1,6 +1,6 @@
 category=Visualization/Reporting
 description=CNES plugin that allows users to download a bundle of project reports in multiple formats.
-homepageUrl=https://github.com/lequal/sonar-cnes-report
+homepageUrl=https://github.com/cnescatlab/sonar-cnes-report
 archivedVersions=3.1.0
 publicVersions=3.2.2
 
@@ -10,10 +10,10 @@ defaults.mavenArtifactId=cnesreport
 3.2.2.description=Support SonarQube 8 up to 8.2 & add ability to export from a specific branch
 3.2.2.date=2020-03-10
 3.2.2.sqVersions=[7.9,8.2]
-3.2.2.changelogUrl=https://github.com/lequal/sonar-cnes-report/releases/tag/3.2.2
-3.2.2.downloadUrl=https://github.com/lequal/sonar-cnes-report/releases/download/3.2.2/sonar-cnes-report-3.2.2.jar
+3.2.2.changelogUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/tag/3.2.2
+3.2.2.downloadUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/download/3.2.2/sonar-cnes-report-3.2.2.jar
 3.1.0.description=Support SonarQube 7.9 LTS and release to marketplace
 3.1.0.date=2019-08-21
 3.1.0.sqVersions=[6.7,8.2]
-3.1.0.changelogUrl=https://github.com/lequal/sonar-cnes-report/releases/tag/3.1.0
-3.1.0.downloadUrl=https://github.com/lequal/sonar-cnes-report/releases/download/3.1.0/sonar-cnes-report-3.1.0.jar
+3.1.0.changelogUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/tag/3.1.0
+3.1.0.downloadUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/download/3.1.0/sonar-cnes-report-3.1.0.jar

--- a/icode.properties
+++ b/icode.properties
@@ -1,6 +1,6 @@
 category=Languages
 description=Code Analyzer for Fortran(77 & 90) and Shell (using i-Code CNES)
-homepageUrl=https://github.com/lequal/sonar-icode-cnes-plugin
+homepageUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin
 archivedVersions=1.0.2,1.1.0,2.0.1
 publicVersions=2.0.2
 
@@ -12,29 +12,29 @@ defaults.mavenArtifactId=sonar-icode-cnes-plugin
 2.0.2.description=Analyze Fortran and Shell on SonarQube 7.9 and 8
 2.0.2.date=2020-04-08
 2.0.2.sqVersions=[7.9,LATEST]
-2.0.2.changelogUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/tag/2.0.2
-2.0.2.downloadUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/2.0.2/sonar-icode-cnes-plugin-2.0.2.jar
+2.0.2.changelogUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/tag/2.0.2
+2.0.2.downloadUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/download/2.0.2/sonar-icode-cnes-plugin-2.0.2.jar
 
 2.0.1.description=i-Code CNES is now embedded in the plugin, no more need to install it
 2.0.1.date=2020-02-14
 2.0.1.sqVersions=[7.9,8.1]
-2.0.1.changelogUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/tag/2.0.1
-2.0.1.downloadUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/2.0.1/sonar-icode-cnes-plugin-2.0.1.jar
+2.0.1.changelogUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/tag/2.0.1
+2.0.1.downloadUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/download/2.0.1/sonar-icode-cnes-plugin-2.0.1.jar
 
 2.0.0.description=i-Code CNES is now embedded in the plugin, no more need to install it
 2.0.0.date=2020-02-14
 2.0.0.sqVersions=[7.9,8.1]
-2.0.0.changelogUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/tag/2.0.0
-2.0.0.downloadUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/2.0.0/sonar-icode-cnes-plugin-2.0.0.jar
+2.0.0.changelogUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/tag/2.0.0
+2.0.0.downloadUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/download/2.0.0/sonar-icode-cnes-plugin-2.0.0.jar
 
 1.1.0.description=Support of i-Code CNES 3.1.0, new rules and metrics
 1.1.0.date=2018-09-19
 1.1.0.sqVersions=[6.7,7.8]
-1.1.0.changelogUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/tag/1.1.0
-1.1.0.downloadUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/1.1.0/sonaricode-1.1.0.jar
+1.1.0.changelogUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/tag/1.1.0
+1.1.0.downloadUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/download/1.1.0/sonaricode-1.1.0.jar
 
 1.0.2.description=Initial Marketplace entry
 1.0.2.date=2018-08-01
 1.0.2.sqVersions=[6.7,7.3]
-1.0.2.changelogUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/tag/1.0.2
-1.0.2.downloadUrl=https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/1.0.2/sonar-icode-cnes-plugin-1.0.2.jar
+1.0.2.changelogUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/tag/1.0.2
+1.0.2.downloadUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/download/1.0.2/sonar-icode-cnes-plugin-1.0.2.jar


### PR DESCRIPTION
Organization `lequal` has been renamed `cnescatlab` please accept these change to get the updated links.

Sincerely,
Benoît