### PR TITLE
Release sonar-findbugs 4.0.2

### DIFF
--- a/findbugs.properties
+++ b/findbugs.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=sonar-findbugs-plugin
 4.0.2.downloadUrl=https://repo.maven.apache.org/maven2/com/github/spotbugs/sonar-findbugs-plugin/4.0.2/sonar-findbugs-plugin-4.0.2.jar
 
 4.0.1.description=Use SpotBugs 4.1.2, sb-contrib 7.4.7, and findsecbugs 1.10.1
-4.0.1.sqVersions=[7.9,8.5]
+4.0.1.sqVersions=[7.9,8.5.*]
 4.0.1.date=2020-09-18
 4.0.1.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/4.0.1
 4.0.1.downloadUrl=https://repo.maven.apache.org/maven2/com/github/spotbugs/sonar-findbugs-plugin/4.0.1/sonar-findbugs-plugin-4.0.1.jar

--- a/findbugs.properties
+++ b/findbugs.properties
@@ -1,13 +1,19 @@
 category=External Analysers
 description=Provide Findbugs rules for analysis of Java projects
-archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.9.3,3.10.0,3.11.0,3.9.4,3.11.1,4.0.0
-publicVersions=4.0.1
+archivedVersions=2.4,3.0,3.1,3.2,3.3,3.4.3,3.4.4,3.5,3.6,3.7,3.8.0,3.9.0,3.9.1,3.9.2,3.9.3,3.10.0,3.11.0,3.9.4,3.11.1,4.0.0,4.0.1
+publicVersions=4.0.2
 
 defaults.mavenGroupId=org.sonarsource.sonar-findbugs-plugin
 defaults.mavenArtifactId=sonar-findbugs-plugin
 
+4.0.2.description=Use SpotBugs 4.2.0, sb-contrib 7.4.7, and findsecbugs 1.11.0
+4.0.2.sqVersions=[7.9,LATEST]
+4.0.2.date=2020-11-30
+4.0.2.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/4.0.2
+4.0.2.downloadUrl=https://repo.maven.apache.org/maven2/com/github/spotbugs/sonar-findbugs-plugin/4.0.2/sonar-findbugs-plugin-4.0.2.jar
+
 4.0.1.description=Use SpotBugs 4.1.2, sb-contrib 7.4.7, and findsecbugs 1.10.1
-4.0.1.sqVersions=[7.9,LATEST]
+4.0.1.sqVersions=[7.9,8.5]
 4.0.1.date=2020-09-18
 4.0.1.changelogUrl=https://github.com/spotbugs/sonar-findbugs/releases/tag/4.0.1
 4.0.1.downloadUrl=https://repo.maven.apache.org/maven2/com/github/spotbugs/sonar-findbugs-plugin/4.0.1/sonar-findbugs-plugin-4.0.1.jar


### PR DESCRIPTION
We've released [sonar-findbugs version 4.0.2](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.0.2), please add it to the marketplace.
Here is [my post at the forum for this change](https://community.sonarsource.com/t/new-release-sonar-findbugs-4-0-2/35166).

Thanks in advance!