### PR TITLE
Update dependency-check-sonar-plugin to 2.0.7

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,13 +1,20 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.2,2.0.3,2.0.4,2.0.5
-publicVersions=2.0.6
+archivedVersions=2.0.2,2.0.3,2.0.4,2.0.5,2.0.6
+publicVersions=2.0.7
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
+
+2.0.7.description=Added support for setting configuration properties on project level.
+2.0.7.sqVersions=[7.9.3, LATEST]
+2.0.7.date=2020-12-22
+2.0.7.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.7
+2.0.7.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.7/sonar-dependency-check-plugin-2.0.7.jar
+
 2.0.6.description=Support dependency-check 6.0.0. Added support for getting the report html for the current branch/pullrequest
-2.0.6.sqVersions=[7.9.3, LATEST]
+2.0.6.sqVersions=[7.9.3, 8.6]
 2.0.6.date=2020-09-15
 2.0.6.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.6
 2.0.6.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.6/sonar-dependency-check-plugin-2.0.6.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 2.0.7 please add it to the marketplace.
Thanks in advance!