### PR TITLE
Add properties file for findbugs-slf4j plugin

### DIFF
--- a/findbugs-slf4j.properties
+++ b/findbugs-slf4j.properties
@@ -1,0 +1,16 @@
+category = External Analysers
+description = Provide Findbugs rules to verify usage of SLF4J
+archivedVersions = 1.4.2
+publicVersions = 1.5.0
+defaults.mavenGroupId = jp.skypencil.findbugs.slf4j
+defaults.mavenArtifactId = sonar-findbugs-slf4j-plugin
+1.5.0.description = Support for new SonarQube v7.9 LTS
+1.5.0.sqVersions = [7.9,LATEST]
+1.5.0.date = 2019-07-04
+1.5.0.changelogUrl = https://github.com/KengoTODA/findbugs-slf4j/releases/tag/findbugs-slf4j-1.5.0
+1.5.0.downloadUrl = https://repo1.maven.org/maven2/jp/skypencil/findbugs/slf4j/sonar-findbugs-slf4j-plugin/1.5.0/sonar-findbugs-slf4j-plugin-1.5.0.jar
+1.4.2.description = Last release for old SonarQube v5.6 LTS
+1.4.2.sqVersions = [5.6,6.7.*]
+1.4.2.date = 2018-10-11
+1.4.2.changelogUrl = https://github.com/KengoTODA/findbugs-slf4j/releases/tag/findbugs-slf4j-1.4.2
+1.4.2.downloadUrl = https://repo1.maven.org/maven2/jp/skypencil/findbugs/slf4j/sonar-findbugs-slf4j-plugin/1.4.2/sonar-findbugs-slf4j-plugin-1.4.2.jar


### PR DESCRIPTION
The findbugs-slf4j plugin depends on findbugs plugin, and it runs analysis for Java class files.
Please review this file, and merge it to release to the marketplace.
