### PR TITLE
Add properties file to release guava-helper-for-java-8 again

### DIFF
--- a/guava-helper-for-java-8.properties
+++ b/guava-helper-for-java-8.properties
@@ -1,0 +1,11 @@
+category = External Analysers
+description = Provide Findbugs rules to verify usage of Guava
+archivedVersions =
+publicVersions = 1.2.0
+defaults.mavenGroupId = jp.skypencil.guava
+defaults.mavenArtifactId = guava-helper-sonarqube-plugin
+1.2.0.description = Support for new SonarQube v7.9 LTS
+1.2.0.sqVersions = [7.9,LATEST]
+1.2.0.date = 2019-07-05
+1.2.0.changelogUrl = https://github.com/KengoTODA/guava-helper-for-java-8/releases/tag/guava-helper-for-java-8-1.2.0
+1.2.0.downloadUrl = https://repo1.maven.org/maven2/jp/skypencil/guava/guava-helper-sonarqube-plugin/1.2.0/guava-helper-sonarqube-plugin-1.2.0.jar


### PR DESCRIPTION
Previously I released [my plugin](https://github.com/KengoTODA/guava-helper-for-java-8) to the marketplace, but I found that the current marketplace does not host it. I probably missed some announcements from SonarSource.

Please review this file, and merge it to release to the marketplace.
Note that [here is the previous request at the community forum](https://community.sonarsource.com/t/request-to-deploy-to-the-marketplace-guava-helper-for-java-8/507/8).
