### PR TITLE
sonar-apigee 3.0.0

### DIFF
--- a/apigee.properties
+++ b/apigee.properties
@@ -1,20 +1,21 @@
 category=External Analyzers
 description=Adds XML rules test Apigee apiproxies.
 homepageUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin
-archivedVersions=2.0.0
-publicVersions=2.1.0
+archivedVersions=2.1.1
+publicVersions=3.0.0
 
 defaults.mavenGroupId=com.arkea.satd.sonar.apigee
 defaults.mavenArtifactId=sonar-apigee-plugin
 
-2.1.0.description=SharedFlow support, new rules
-2.1.0.sqVersions=[7.9,8.7.*]
-2.1.0.date=2020-04-08
-2.1.0.changelogUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/tag/v2.1.0
-2.1.0.downloadUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/download/v2.1.0/sonar-apigee-plugin-2.1.0.jar
+3.0.0.description=SharedFlow support, new rules
+3.0.0.sqVersions=[8.8,LATEST]
+3.0.0.date=2021-05-28
+3.0.0.changelogUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/tag/v3.0.0
+3.0.0.downloadUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/download/v3.0.0/sonar-apigee-plugin-3.0.0.jar
 
-2.0.0.description=Support SonarXML 2.0.1+
-2.0.0.sqVersions=[7.9,8.2]
-2.0.0.date=2019-04-04
-2.0.0.changelogUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/tag/v2.0.0
-2.0.0.downloadUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/download/v2.0.0/sonar-apigee-plugin-2.0.0.jar
+2.1.1.description=SharedFlow support, new rules
+2.1.1.sqVersions=[7.9,8.7.*]
+2.1.1.date=2021-05-27
+2.1.1.changelogUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/tag/v2.1.1
+2.1.1.downloadUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/download/v2.1.1/sonar-apigee-plugin-2.1.1.jar
+

--- a/apigee.properties
+++ b/apigee.properties
@@ -1,8 +1,9 @@
 category=External Analyzers
 description=Adds XML rules test Apigee apiproxies.
 homepageUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin
-archivedVersions=2.1.1
-publicVersions=3.0.0
+archivedVersions=2.0.0
+publicVersions=2.1.1,3.0.0
+
 
 defaults.mavenGroupId=com.arkea.satd.sonar.apigee
 defaults.mavenArtifactId=sonar-apigee-plugin


### PR DESCRIPTION
Declare release 3.0.0 for SQ 8.8+
Keep 2.1.1 for older SQ version
End of life of 2.0.0