### PR TITLE
Request to add Licensecheck Plugin to SonarQube marketplace

### DIFF
--- a/licensecheck.properties
+++ b/licensecheck.properties
@@ -1,25 +1,15 @@
 category=Languages
 name=License Check
 description=Checks Maven, Gradle and NPM project for license violations
+homepageUrl=https://github.com/porscheinformatik/sonarqube-licensecheck
 issueTrackerUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/issues
-devVersion=5.0.0-beta-2
 publicVersions=4.0.2
-archivedVersions=3.2.0
 
 defaults.mavenGroupId=at.porscheinformatik.sonarqube.licensecheck
 defaults.mavenArtifactId=sonarqube-licensecheck-plugin
 
-5.0.0-beta-2.description=JavaScript-only and Groovy-only projects, configuration uses default functionality
-5.0.0-beta-2.sqVersions=[8.9,LATEST]
-
-4.0.2.description=fix: create license with status disallowed
+4.0.2.description=initial Marketplace entry
 4.0.2.sqVersions=[8.4,8.9.*]
 4.0.2.downloadUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/download/v4.0.2/sonarqube-licensecheck-plugin-4.0.2.jar
 4.0.2.date=2021-05-04
 4.0.2.changelogUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/tag/v4.0.2
-
-3.2.0.description=Gradle support, NPM transitive check config
-3.2.0.sqVersions=[7.9,7.9.*]
-3.2.0.downloadUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/download/v3.2.0/sonarqube-licensecheck-plugin-3.2.0.jar
-3.2.0.date=2020-07-17
-3.2.0.changelogUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/tag/v3.2.0

--- a/licensecheck.properties
+++ b/licensecheck.properties
@@ -1,0 +1,25 @@
+category=Languages
+name=License Check
+description=Checks Maven, Gradle and NPM project for license violations
+issueTrackerUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/issues
+devVersion=5.0.0-beta-2
+publicVersions=4.0.2
+archivedVersions=3.2.0
+
+defaults.mavenGroupId=at.porscheinformatik.sonarqube.licensecheck
+defaults.mavenArtifactId=sonarqube-licensecheck-plugin
+
+5.0.0-beta-2.description=JavaScript-only and Groovy-only projects, configuration uses default functionality
+5.0.0-beta-2.sqVersions=[8.9,LATEST]
+
+4.0.2.description=fix: create license with status disallowed
+4.0.2.sqVersions=[8.4,8.9.*]
+4.0.2.downloadUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/download/v4.0.2/sonarqube-licensecheck-plugin-4.0.2.jar
+4.0.2.date=2021-05-04
+4.0.2.changelogUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/tag/v4.0.2
+
+3.2.0.description=Gradle support, NPM transitive check config
+3.2.0.sqVersions=[7.9,7.9.*]
+3.2.0.downloadUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/download/v3.2.0/sonarqube-licensecheck-plugin-3.2.0.jar
+3.2.0.date=2020-07-17
+3.2.0.changelogUrl=https://github.com/porscheinformatik/sonarqube-licensecheck/releases/tag/v3.2.0


### PR DESCRIPTION
At Porsche Informatik we have created a SonarQube plugin to check for license violations. We are using this plugin since 2016 in production. In the last 2 years many additional users got involved in the project. Now, we want to add it to the marketplace to make install/update for our users easier.

Here is the plugin page (with issues. etc.): https://github.com/porscheinformatik/sonarqube-licensecheck