### PR TITLE
Update aemrules.properties

### DIFF
--- a/aemrules.properties
+++ b/aemrules.properties
@@ -8,7 +8,7 @@ defaults.mavenGroupId=com.cognifide.aemrules
 defaults.mavenArtifactId=sonar-aemrules-plugin
 
 1.3.description=Brought back Java 8 compatibility to allow the rules to be used outside SonarQube Server.
-1.3.sqVersions=[7.9,LATEST]
+1.3.sqVersions=[7.9,8.8]
 1.3.date=2020-10-23
 1.3.changelogUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/tag/v1.3
 1.3.downloadUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/download/v1.3/sonar-aemrules-plugin-1.3.jar


### PR DESCRIPTION
This plugin is not compatible with 8.9 based on Community and Support requests, as well as this issue on the repository:

https://github.com/wttech/AEM-Rules-for-SonarQube/issues/213