### PR TITLE
Add crowd 2.2.0

### DIFF
--- a/crowd.properties
+++ b/crowd.properties
@@ -2,15 +2,21 @@ category=Integration
 description=Provide the ability to authenticate again Crowd
 homepageUrl=https://github.com/deepy/sonar-crowd
 devVersion=
-publicVersions=2.1.3
-archivedVersions=
+publicVersions=2.2.0
+archivedVersions=2.1.3
 privateVersions=
 
 defaults.mavenGroupId=cm.xd.sonar-plugins
 defaults.mavenArtifactId=sonar-crowd-plugin
 
+2.2.0.description=Support 8.9+
+2.2.0.sqVersions=[8.9,LATEST]
+2.2.0.date=2021-07-14
+2.2.0.changelogUrl=https://github.com/deepy/sonar-crowd/releases/tag/2.2.0
+2.2.0.downloadUrl=https://github.com/deepy/sonar-crowd/releases/download/2.2.0/sonar-crowd-plugin-2.2.0.jar
+
 2.1.3.description=Support 7.9+
-2.1.3.sqVersions=[7.9,LATEST]
-2.1.3.date=2019-07-14
+2.1.3.sqVersions=[7.9,8.1]
+2.1.3.date=2019-07-17
 2.1.3.changelogUrl=https://github.com/deepy/sonar-crowd/releases/tag/2.1.3
 2.1.3.downloadUrl=https://github.com/deepy/sonar-crowd/releases/download/2.1.3/sonar-crowd-plugin-2.1.3.jar


### PR DESCRIPTION
Crowd 2.2.0 has just been released to add support for 8.9+

I'm not 100% sure what version it stopped working with so I added 8.1 as project-wise we don't support anything older than current LTS