### PR TITLE
Update icode.properties

### DIFF
--- a/icode.properties
+++ b/icode.properties
@@ -11,7 +11,7 @@ defaults.mavenArtifactId=sonar-icode-cnes-plugin
 
 2.0.2.description=Analyze Fortran and Shell on SonarQube 7.9 and 8
 2.0.2.date=2020-04-08
-2.0.2.sqVersions=[7.9,LATEST]
+2.0.2.sqVersions=[7.9,8.2]
 2.0.2.changelogUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/tag/2.0.2
 2.0.2.downloadUrl=https://github.com/cnescatlab/sonar-icode-cnes-plugin/releases/download/2.0.2/sonar-icode-cnes-plugin-2.0.2.jar
 


### PR DESCRIPTION
https://github.com/cnescatlab/sonar-icode-cnes-plugin only reports compatability up to 8.2. Maybe we should believe them? 

https://community.sonarsource.com/t/upgrade-to-9-1-fails-background-initialization-failed-stopping-sonarqube/48940