### PR TITLE
Update incorrect .NET Core Global Tool links for scannermsbuild 5.2.2 and 5.3.1 releases

### DIFF
--- a/scannermsbuild.properties
+++ b/scannermsbuild.properties
@@ -19,7 +19,7 @@ flavors.framework46.label=.NET Framework 4.6+
 5.3.1.date=2021-09-01
 5.3.1.changelogUrl=https://github.com/SonarSource/sonar-scanner-msbuild/releases/tag/5.3.1.36242
 5.3.1.downloadUrl.net5=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.3.1.36242/sonar-scanner-msbuild-5.3.1.36242-net5.0.zip
-5.3.1.downloadUrl.core=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.3.1.36242/sonar-scanner-msbuild-5.3.1.36242-netcoreapp3.0.zip
+5.3.1.downloadUrl.core=https://www.nuget.org/packages/dotnet-sonarscanner
 5.3.1.downloadUrl.core20=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.3.1.36242/sonar-scanner-msbuild-5.3.1.36242-netcoreapp2.0.zip
 5.3.1.downloadUrl.framework46=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.3.1.36242/sonar-scanner-msbuild-5.3.1.36242-net46.zip
 
@@ -27,7 +27,7 @@ flavors.framework46.label=.NET Framework 4.6+
 5.2.2.date=2021-06-24
 5.2.2.changelogUrl=https://github.com/SonarSource/sonar-scanner-msbuild/releases/tag/5.2.2.33595
 5.2.2.downloadUrl.net5=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.2.2.33595/sonar-scanner-msbuild-5.2.2.33595-net5.0.zip
-5.2.2.downloadUrl.core=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.2.2.33595/sonar-scanner-msbuild-5.2.2.33595-netcoreapp3.0.zip
+5.2.2.downloadUrl.core=https://www.nuget.org/packages/dotnet-sonarscanner
 5.2.2.downloadUrl.core20=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.2.2.33595/sonar-scanner-msbuild-5.2.2.33595-netcoreapp2.0.zip
 5.2.2.downloadUrl.framework46=https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.2.2.33595/sonar-scanner-msbuild-5.2.2.33595-net46.zip
 


### PR DESCRIPTION
Update center links for Sonar Scanner for .NET are incorrect for the .NET Core Global Tool for release 5.2.2 and 5.3.1: https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-msbuild/

Also, why do we not show the release link for .NET Core 3.0?