### PR TITLE
Update Hadolint plugin with version 1.1.0

### DIFF
--- a/hadolint.properties
+++ b/hadolint.properties
@@ -1,11 +1,18 @@
 category=External Analyzers
 description=Sonar Hadolint Plugin allows users to import results from Hadolint into SonarQube. To do this, it creates a Dockerfile language with highlightings & metrics, and a Quality Profile with Hadolint & Shellcheck rules.
 homepageUrl=https://github.com/cnescatlab/sonar-hadolint-plugin
-archivedVersions=
-publicVersions=1.0.0
+archivedVersions=1.0.0
+publicVersions=1.1.0
 
 defaults.mavenGroupId=fr.cnes.sonarqube.plugins
 defaults.mavenArtifactId=sonar-hadolint-plugin
+
+
+1.1.0.description=Update rules with Shellcheck plugin 2.4.0 & Hadolint 2.6.1, add hability to use wildcards in reports path, and fix a bug regarding absolute paths for reports.
+1.1.0.date=2021-09-23
+1.1.0.sqVersions=[8.9,LATEST]
+1.1.0.changelogUrl=https://github.com/cnescatlab/sonar-hadolint-plugin/releases/tag/1.1.0
+1.1.0.downloadUrl=https://github.com/cnescatlab/sonar-hadolint-plugin/releases/download/1.1.0/sonar-hadolint-plugin-1.1.0.jar
 
 1.0.0.description=Initial release
 1.0.0.date=2020-10-22

--- a/hadolint.properties
+++ b/hadolint.properties
@@ -16,6 +16,6 @@ defaults.mavenArtifactId=sonar-hadolint-plugin
 
 1.0.0.description=Initial release
 1.0.0.date=2020-10-22
-1.0.0.sqVersions=[7.9,LATEST]
+1.0.0.sqVersions=[7.9,8.9]
 1.0.0.changelogUrl=https://github.com/cnescatlab/sonar-hadolint-plugin/releases/tag/1.0.0
 1.0.0.downloadUrl=https://github.com/cnescatlab/sonar-hadolint-plugin/releases/download/1.0.0/sonar-hadolint-plugin-1.0.0.jar

--- a/hadolint.properties
+++ b/hadolint.properties
@@ -16,6 +16,6 @@ defaults.mavenArtifactId=sonar-hadolint-plugin
 
 1.0.0.description=Initial release
 1.0.0.date=2020-10-22
-1.0.0.sqVersions=[7.9,8.9]
+1.0.0.sqVersions=[7.9,9.1]
 1.0.0.changelogUrl=https://github.com/cnescatlab/sonar-hadolint-plugin/releases/tag/1.0.0
 1.0.0.downloadUrl=https://github.com/cnescatlab/sonar-hadolint-plugin/releases/download/1.0.0/sonar-hadolint-plugin-1.0.0.jar


### PR DESCRIPTION
# Changelog
* Update shell rules with Shellcheck plugin 2.4.0
* Update Dockerfile rules with Hadolint 2.6.1
* Add a default value for Dockerfiles list
* Add ability to list Hadolint reports using wildcards
* Fix an error whn using absolute paths for Hadolint reports
 
And more details here : https://github.com/cnescatlab/sonar-hadolint-plugin/releases/tag/1.1.0