### PR TITLE
Update sonar-detekt to 2.4.0

### DIFF
--- a/detekt.properties
+++ b/detekt.properties
@@ -8,13 +8,13 @@ defaults.mavenGroupId=io.github.detekt
 defaults.mavenArtifactId=sonar-detekt
 
 2.4.0.description=Upgrade to detekt 1.18.1
-2.4.0.sqVersions=[7.9.4,LATEST]
+2.4.0.sqVersions=[8.9,LATEST]
 2.4.0.date=2021-10-31
 2.4.0.changelogUrl=https://github.com/detekt/sonar-kotlin/releases/tag/2.4.0
 2.4.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.4.0/sonar-detekt-2.4.0.jar
 
 2.3.0.description=Upgrade to detekt 1.14.1
-2.3.0.sqVersions=[7.9.4,8.9.3]
+2.3.0.sqVersions=[7.9.4,9.2.*]
 2.3.0.date=2020-10-01
 2.3.0.changelogUrl=https://github.com/detekt/sonar-kotlin/releases/tag/2.3.0
 2.3.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.3.0/sonar-detekt-2.3.0.jar

--- a/detekt.properties
+++ b/detekt.properties
@@ -1,8 +1,8 @@
 category=External Analysers
 description=Provide detekt rules for Kotlin projects
 homepageUrl=https://github.com/detekt/sonar-kotlin
-archivedVersions=2.0.0,2.2.0
-publicVersions=2.1.0,2.3.0,2.4.0
+archivedVersions=2.0.0,2.2.0,2.3.0
+publicVersions=2.1.0,2.4.0
 
 defaults.mavenGroupId=io.github.detekt
 defaults.mavenArtifactId=sonar-detekt
@@ -14,7 +14,7 @@ defaults.mavenArtifactId=sonar-detekt
 2.4.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.4.0/sonar-detekt-2.4.0.jar
 
 2.3.0.description=Upgrade to detekt 1.14.1
-2.3.0.sqVersions=[7.9.4,LATEST]
+2.3.0.sqVersions=[7.9.4,8.9.3]
 2.3.0.date=2020-10-01
 2.3.0.changelogUrl=https://github.com/detekt/sonar-kotlin/releases/tag/2.3.0
 2.3.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.3.0/sonar-detekt-2.3.0.jar

--- a/detekt.properties
+++ b/detekt.properties
@@ -2,10 +2,16 @@ category=External Analysers
 description=Provide detekt rules for Kotlin projects
 homepageUrl=https://github.com/detekt/sonar-kotlin
 archivedVersions=2.0.0,2.2.0
-publicVersions=2.1.0,2.3.0
+publicVersions=2.1.0,2.3.0,2.4.0
 
 defaults.mavenGroupId=io.github.detekt
 defaults.mavenArtifactId=sonar-detekt
+
+2.4.0.description=Upgrade to detekt 1.18.1
+2.4.0.sqVersions=[7.9.4,LATEST]
+2.4.0.date=2021-10-31
+2.4.0.changelogUrl=https://github.com/detekt/sonar-kotlin/releases/tag/2.4.0
+2.4.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.4.0/sonar-detekt-2.4.0.jar
 
 2.3.0.description=Upgrade to detekt 1.14.1
 2.3.0.sqVersions=[7.9.4,LATEST]


### PR DESCRIPTION
We released `sonar-detekt` version `2.4.0`, see: https://github.com/detekt/sonar-kotlin/releases/tag/2.4.0

Sadly I don't have a SonarQube instance where I can try this, so I'm just copying the values from the previous version.