### PR TITLE
Update sonar-detekt to 2.5.0

### DIFF
--- a/detekt.properties
+++ b/detekt.properties
@@ -1,14 +1,20 @@
 category=External Analysers
 description=Provide detekt rules for Kotlin projects
 homepageUrl=https://github.com/detekt/sonar-kotlin
-archivedVersions=2.0.0,2.2.0,2.3.0
-publicVersions=2.1.0,2.4.0
+archivedVersions=2.0.0,2.2.0,2.3.0,2.4.0
+publicVersions=2.1.0,2.5.0
 
 defaults.mavenGroupId=io.github.detekt
 defaults.mavenArtifactId=sonar-detekt
 
+2.5.0.description=Upgrade to detekt 1.19.0
+2.5.0.sqVersions=[8.9,LATEST]
+2.5.0.date=2022-01-10
+2.5.0.changelogUrl=https://github.com/detekt/sonar-kotlin/releases/tag/2.5.0
+2.5.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.5.0/sonar-detekt-2.5.0.jar
+
 2.4.0.description=Upgrade to detekt 1.18.1
-2.4.0.sqVersions=[8.9,LATEST]
+2.4.0.sqVersions=[8.9,9.2.*]
 2.4.0.date=2021-10-31
 2.4.0.changelogUrl=https://github.com/detekt/sonar-kotlin/releases/tag/2.4.0
 2.4.0.downloadUrl=https://github.com/detekt/sonar-kotlin/releases/download/2.4.0/sonar-detekt-2.4.0.jar

--- a/detekt.properties
+++ b/detekt.properties
@@ -1,8 +1,8 @@
 category=External Analysers
 description=Provide detekt rules for Kotlin projects
 homepageUrl=https://github.com/detekt/sonar-kotlin
-archivedVersions=2.0.0,2.2.0,2.3.0,2.4.0
-publicVersions=2.1.0,2.5.0
+archivedVersions=2.0.0,2.1.0,2.2.0,2.3.0,2.4.0
+publicVersions=2.5.0
 
 defaults.mavenGroupId=io.github.detekt
 defaults.mavenArtifactId=sonar-detekt


### PR DESCRIPTION
We released sonar-detekt version 2.5.0, see: https://github.com/detekt/sonar-kotlin/releases/tag/2.5.0

which now bundles Detekt 1.19.0.