### PR TITLE
Update sonar-dependency-check-plugin to 3.0.0

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,14 +1,20 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.2,2.0.3,2.0.4,2.0.5,2.0.6,2.0.7
-publicVersions=2.0.8
+archivedVersions=2.0.2,2.0.3,2.0.4,2.0.5,2.0.6,2.0.7,2.0.8
+publicVersions=3.0.0
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
 
+3.0.0.description=Update Plugin to SonarQube 8 API and deprecate XML-Reports
+3.0.0.sqVersions=[8.9.7, LATEST]
+3.0.0.date=2022-02-10
+3.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.0.0
+3.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.0.0/sonar-dependency-check-plugin-3.0.0.jar
+
 2.0.8.description=Maintenance version with library updates
-2.0.8.sqVersions=[7.9.3, LATEST]
+2.0.8.sqVersions=[7.9.3, 9.3]
 2.0.8.date=2021-05-31
 2.0.8.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.8
 2.0.8.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.8/sonar-dependency-check-plugin-2.0.8.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 3.0.0, please add it to the marketplace.
Thanks in advance!