### PR TITLE
Update sonar-dependency-check-plugin to 3.0.1

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,14 +1,19 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.2,2.0.3,2.0.4,2.0.5,2.0.6,2.0.7,2.0.8
-publicVersions=3.0.0
+archivedVersions=2.0.2,2.0.3,2.0.4,2.0.5,2.0.6,2.0.7,2.0.8,3.0.0
+publicVersions=3.0.1
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
+3.0.1.description=Restore JDK8 compatibility
+3.0.1.sqVersions=[8.9.7, LATEST]
+3.0.1.date=2022-02-24
+3.0.1.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.0.1
+3.0.1.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.0.1/sonar-dependency-check-plugin-3.0.1.jar
 
 3.0.0.description=Update Plugin to SonarQube 8 API and deprecate XML-Reports
-3.0.0.sqVersions=[8.9.7, LATEST]
+3.0.0.sqVersions=[8.9.7, 9.3]
 3.0.0.date=2022-02-10
 3.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.0.0
 3.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.0.0/sonar-dependency-check-plugin-3.0.0.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 3.0.1, please add it to the marketplace.
Thanks in advance!