### PR TITLE
Add Sonar CNES Report version 4.1.0

### DIFF
--- a/cnesreport.properties
+++ b/cnesreport.properties
@@ -1,11 +1,17 @@
 category=Visualization/Reporting
 description=CNES plugin that allows users to download a bundle of project reports in multiple formats.
 homepageUrl=https://github.com/cnescatlab/sonar-cnes-report
-archivedVersions=3.1.0,3.2.2,3.3.1
-publicVersions=4.0.0
+archivedVersions=3.1.0,3.2.2,3.3.1,4.0.0
+publicVersions=4.1.0
 
 defaults.mavenGroupId=fr.cnes.sonarqube.plugins
 defaults.mavenArtifactId=cnesreport
+
+4.1.0.description=Refactoring to ease future features, add tests metrics summary in report, allow the plugin to run on non-compatible SonarQube releases (but show a warning) and some bugfixes.
+4.1.0.date=2022-02-22
+4.1.0.sqVersions=8.9.*
+4.1.0.changelogUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.0
+4.1.0.downloadUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/download/4.1.0/sonar-cnes-report-4.1.0.jar
 
 4.0.0.description=Add compatibility with SonarQube 8.9 LTS, enhance reports with new metrics (quality gate status, adherence to coding standard, etc.) and graphs (number of issues, technical debt ratio), and various bugfixes.
 4.0.0.date=2021-09-23


### PR DESCRIPTION
# Changelog

* Some refactoring to ease future features
* Add tests metrics summary in report (total tests, success rate, failures, ...)
* Allow the plugin to run on non-compatible SonarQube releases (but show a warning)
* Some bugfixes
 
And more details here : https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.0

*Compatibility only includes 8.9.x LTS because we rely a lot on SQ APIs. 9.x versions may change them, and we don't have enough time to maintain the plugin for every intermediate SQ release before the next LTS.*