### PR TITLE
AEM Rules for SonarQube release 1.5

### DIFF
--- a/aemrules.properties
+++ b/aemrules.properties
@@ -1,11 +1,17 @@
 category=External Analysers
 description=Adds rules for AEM Java development
 homepageUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube
-archivedVersions=0.11,1.0,1.1,1.2
-publicVersions=1.3
+archivedVersions=0.11,1.0,1.1,1.2,1.3
+publicVersions=1.5
 
 defaults.mavenGroupId=com.cognifide.aemrules
 defaults.mavenArtifactId=sonar-aemrules-plugin
+
+1.5.description=SonarQube 8.9 LTS compatiblity release due to underlying Java plugin API changes
+1.5.sqVersions=[8.9,LATEST]
+1.5.date=2022-04-07
+1.5.changelogUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/tag/v1.5
+1.5.downloadUrl=https://github.com/Cognifide/AEM-Rules-for-SonarQube/releases/download/v1.5/sonar-aemrules-plugin-1.5.jar
 
 1.3.description=Brought back Java 8 compatibility to allow the rules to be used outside SonarQube Server.
 1.3.sqVersions=[7.9,8.8]


### PR DESCRIPTION
Compatibility update to SonarQube 8.9 LTS. There have been breaking API changes in the Sonar Java plugin that AEM Rules use as a depenency. This release removes reliance on no longer available methods, preventing runtime failures.

Release 1.4 has been discarded, skipped and shouldn't be available for
download.