### PR TITLE
Add Chris and Ann as co-codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/sonarqube-team
+.github/CODEOWNERS @sonarsource/sonarqube-team @christophelevis @ganncamp


### PR DESCRIPTION
Hello folks,

In the current situation, only the SonarQube team members are declared as "code owners" of this repo. In reality, @christophelevis and @ganncamp are the ones updating it. With this PR, I'm making official this, meaning that Chris and Ann are co-responsible with the SQ team of this repository.

Chris, Ann, let me know if you think that makes sense.