### PR TITLE
Add cnesreport 4.1.1 release

### DIFF
--- a/cnesreport.properties
+++ b/cnesreport.properties
@@ -1,11 +1,17 @@
 category=Visualization/Reporting
 description=CNES plugin that allows users to download a bundle of project reports in multiple formats.
 homepageUrl=https://github.com/cnescatlab/sonar-cnes-report
-archivedVersions=3.1.0,3.2.2,3.3.1,4.0.0
-publicVersions=4.1.0
+archivedVersions=3.1.0,3.2.2,3.3.1,4.0.0,4.1.0
+publicVersions=4.1.1
 
 defaults.mavenGroupId=fr.cnes.sonarqube.plugins
 defaults.mavenArtifactId=cnesreport
+
+4.1.1.description=Fix an issue where the plugin produces an unreadable Word report.
+4.1.1.date=2022-04-26
+4.1.1.sqVersions=8.9.*
+4.1.1.changelogUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.1
+4.1.1.downloadUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/download/4.1.1/sonar-cnes-report-4.1.1.jar
 
 4.1.0.description=Refactoring to ease future features, add tests metrics summary in report, allow the plugin to run on non-compatible SonarQube releases (but show a warning) and some bugfixes.
 4.1.0.date=2022-02-22


### PR DESCRIPTION
# Changelog

* Fix a bug where an unreadable Word report is generated
 
And more details here : https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.1

*Compatibility only includes 8.9.x LTS because we rely a lot on SQ APIs. 9.x versions may change them, and we don't have enough time to maintain the plugin for every intermediate SQ release before the next LTS.*