### PR TITLE
Remove individuals from ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/sonarqube-team @christophelevis @ganncamp @colin-sonarsource
+.github/CODEOWNERS @sonarsource/sonarqube-team


### PR DESCRIPTION
According to https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2169339970/GitHub+Authentication+Authorization#CODEOWNERS, only one team can be the "owner".