### PR TITLE
new sonar-pmd-plugin: 3.4.0

### DIFF
--- a/pmd.properties
+++ b/pmd.properties
@@ -1,15 +1,15 @@
 category=External Analysers
 description=Provide PMD rules to analyse Java projects
-archivedVersions=
-#publicVersions=3.3.1
+archivedVersions=3.3.1
+publicVersions=3.4.0
 
 defaults.mavenGroupId=org.sonarsource.pmd
 defaults.mavenArtifactId=sonar-pmd-plugin
 
-3.3.1.description=Upgrade to PMD 6.30 and Java 15 support
-#3.3.1.sqVersions=[8.9,LATEST]
-3.3.1.date=2021-02-06
-3.3.1.changelogUrl=https://github.com/jensgerdes/sonar-pmd/releases/tag/3.3.1
-3.3.1.downloadUrl=https://github.com/jensgerdes/sonar-pmd/releases/download/3.3.1/sonar-pmd-plugin-3.3.1.jar
+3.4.0.description=Upgrade to PMD 6.45 and Java 18 support
+3.4.0.sqVersions=[8.9,LATEST]
+3.4.0.date=2022-05-11
+3.4.0.changelogUrl=https://github.com/jborgers/sonar-pmd/releases/tag/3.4.0
+3.4.0..downloadUrl=https://github.com/jborgers/sonar-pmd/releases/download/3.4.0/sonar-pmd-plugin-3.4.0.jar
 
 #========================

--- a/pmd.properties
+++ b/pmd.properties
@@ -12,4 +12,10 @@ defaults.mavenArtifactId=sonar-pmd-plugin
 3.4.0.changelogUrl=https://github.com/jborgers/sonar-pmd/releases/tag/3.4.0
 3.4.0..downloadUrl=https://github.com/jborgers/sonar-pmd/releases/download/3.4.0/sonar-pmd-plugin-3.4.0.jar
 
+3.3.1.description=Upgrade to PMD 6.30 and Java 15 support
+3.3.1.sqVersions=[8.9,LATEST]
+3.3.1.date=2021-02-06
+3.3.1.changelogUrl=https://github.com/jensgerdes/sonar-pmd/releases/tag/3.3.1
+3.3.1.downloadUrl=https://github.com/jensgerdes/sonar-pmd/releases/download/3.3.1/sonar-pmd-plugin-3.3.1.jar
+
 #========================

--- a/pmd.properties
+++ b/pmd.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=sonar-pmd-plugin
 3.4.0..downloadUrl=https://github.com/jborgers/sonar-pmd/releases/download/3.4.0/sonar-pmd-plugin-3.4.0.jar
 
 3.3.1.description=Upgrade to PMD 6.30 and Java 15 support
-3.3.1.sqVersions=[8.9,LATEST]
+3.3.1.sqVersions=[8.9,9.4]
 3.3.1.date=2021-02-06
 3.3.1.changelogUrl=https://github.com/jensgerdes/sonar-pmd/releases/tag/3.3.1
 3.3.1.downloadUrl=https://github.com/jensgerdes/sonar-pmd/releases/download/3.3.1/sonar-pmd-plugin-3.3.1.jar


### PR DESCRIPTION
We released a new version of the sonar-pmd-plugin to support Java 18 and Sonar 8.9/9. Please make it available in the marketplace. Thanks!