### PR TITLE
shorten compatibility range per community

### DIFF
--- a/crowd.properties
+++ b/crowd.properties
@@ -9,7 +9,7 @@ defaults.mavenGroupId=cm.xd.sonar-plugins
 defaults.mavenArtifactId=sonar-crowd-plugin
 
 2.1.3.description=Support 7.9+
-2.1.3.sqVersions=[8.9,LATEST]
+2.1.3.sqVersions=[8.9,8.9.*]
 2.1.3.date=2019-07-14
 2.1.3.changelogUrl=https://github.com/deepy/sonar-crowd/releases/tag/2.1.3
 2.1.3.downloadUrl=https://github.com/deepy/sonar-crowd/releases/download/2.1.3/sonar-crowd-plugin-2.1.3.jar


### PR DESCRIPTION
https://community.sonarsource.com/t/sonarqube-does-not-get-user-info-from-crowd-after-update-to-9-4/63860