### PR TITLE
Add CNES Report version 4.1.2

### DIFF
--- a/cnesreport.properties
+++ b/cnesreport.properties
@@ -1,11 +1,17 @@
 category=Visualization/Reporting
 description=CNES plugin that allows users to download a bundle of project reports in multiple formats.
 homepageUrl=https://github.com/cnescatlab/sonar-cnes-report
-archivedVersions=4.0.0,4.1.0
-publicVersions=4.1.1
+archivedVersions=4.0.0,4.1.0,4.1.1
+publicVersions=4.1.2
 
 defaults.mavenGroupId=fr.cnes.sonarqube.plugins
 defaults.mavenArtifactId=cnesreport
+
+4.1.2.description=Fix issues on the project name on Windows, a warning in logs, Security Hotspots categories and missing information for external issues.
+4.1.2date=2022-06-13
+4.1.2.sqVersions=8.9.*
+4.1.2.changelogUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.2
+4.1.2.downloadUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/download/4.1.2/sonar-cnes-report-4.1.2.jar
 
 4.1.1.description=Fix an issue where the plugin produces an unreadable Word report.
 4.1.1.date=2022-04-26

--- a/cnesreport.properties
+++ b/cnesreport.properties
@@ -8,7 +8,7 @@ defaults.mavenGroupId=fr.cnes.sonarqube.plugins
 defaults.mavenArtifactId=cnesreport
 
 4.1.2.description=Fix issues on the project name on Windows, a warning in logs, Security Hotspots categories and missing information for external issues.
-4.1.2date=2022-06-13
+4.1.2.date=2022-06-13
 4.1.2.sqVersions=8.9.*
 4.1.2.changelogUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.2
 4.1.2.downloadUrl=https://github.com/cnescatlab/sonar-cnes-report/releases/download/4.1.2/sonar-cnes-report-4.1.2.jar


### PR DESCRIPTION
# Changelog

* Fix a bug on project name with special chars on Windows
* Add missing Security Hotpsots categories
* Add missing data on external issues
* Fix a warning seen in logs
 
And more details here : https://github.com/cnescatlab/sonar-cnes-report/releases/tag/4.1.2

*Compatibility only includes 8.9.x LTS because we rely a lot on SQ APIs. 9.x versions may change them, and we don't have enough time to maintain the plugin for every intermediate SQ release before the next LTS.*

PS : We also noticed that CNES Report plugin won't be allowed in the SonarQube Marketplace starting with its 9.5 release, because the Enterprise edition now has similar features. We will only publish updates for 8.9 then, so that may be one of our last PR... :cry: 