### PR TITLE
ibmix-aem-sonar-rules 1.2

### DIFF
--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -14,7 +14,7 @@ defaults.mavenArtifactId=ibmix-aem-sonar-rules
 1.2.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.2/ibmix-aem-sonar-rules-1.2.jar
 
 1.1.description=Initial release of the IBM iX AEM rules plugin
-1.1.sqVersions=[9.0,LATEST]
+1.1.sqVersions=[9.0,9.5]
 1.1.date=2022-05-03
 1.1.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.1
 1.1.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.1/ibmix-aem-sonar-rules-1.1.jar

--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=ibmix-aem-sonar-rules
 1.2.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.2/ibmix-aem-sonar-rules-1.2.jar
 
 1.1.description=Initial release of the IBM iX AEM rules plugin
-1.1.sqVersions=[9.0,LATEST]
+1.1.sqVersions=[9.0,9.*]
 1.1.date=2022-05-03
 1.1.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.1
 1.1.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.1/ibmix-aem-sonar-rules-1.1.jar

--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -1,20 +1,19 @@
 category=External Analysers
 description=Plugin containing custom Sonar rules for AEM development based on IBM iX internal guidelines
 homepageUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin
-archivedVersions=1.1
-publicVersions=1.2
+publicVersions=1.1,1.2
 
 defaults.mavenGroupId=ix.ibm.sonar.java.rules
 defaults.mavenArtifactId=ibmix-aem-sonar-rules
 
 1.2.description=Expanded compatibility to include the LTS version
-1.2.sqVersions=[8.9,LATEST]
+1.2.sqVersions=[8.9,8.9.*]
 1.2.date=2022-06-28
 1.2.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.2
 1.2.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.2/ibmix-aem-sonar-rules-1.2.jar
 
 1.1.description=Initial release of the IBM iX AEM rules plugin
-1.1.sqVersions=[9.0,9.5]
+1.1.sqVersions=[9.0,LATEST]
 1.1.date=2022-05-03
 1.1.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.1
 1.1.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.1/ibmix-aem-sonar-rules-1.1.jar

--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -1,19 +1,20 @@
 category=External Analysers
 description=Plugin containing custom Sonar rules for AEM development based on IBM iX internal guidelines
 homepageUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin
-publicVersions=1.1,1.2
+archivedVersions=1.1
+publicVersions=1.2
 
 defaults.mavenGroupId=ix.ibm.sonar.java.rules
 defaults.mavenArtifactId=ibmix-aem-sonar-rules
 
 1.2.description=Expanded compatibility to include the LTS version
-1.2.sqVersions=[8.9,8.9.*]
+1.2.sqVersions=[8.9,LATEST]
 1.2.date=2022-06-28
 1.2.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.2
 1.2.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.2/ibmix-aem-sonar-rules-1.2.jar
 
 1.1.description=Initial release of the IBM iX AEM rules plugin
-1.1.sqVersions=[9.0,9.*]
+1.1.sqVersions=[9.0,9.5]
 1.1.date=2022-05-03
 1.1.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.1
 1.1.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.1/ibmix-aem-sonar-rules-1.1.jar

--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -1,10 +1,17 @@
 category=External Analysers
 description=Plugin containing custom Sonar rules for AEM development based on IBM iX internal guidelines
 homepageUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin
-publicVersions=1.1
+archivedVersions=1.1
+publicVersions=1.2
 
 defaults.mavenGroupId=ix.ibm.sonar.java.rules
 defaults.mavenArtifactId=ibmix-aem-sonar-rules
+
+1.2.description=Expanded compatibility to include the LTS version
+1.2.sqVersions=[8.9,LATEST]
+1.2.date=2022-06-28
+1.2.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.2
+1.2.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.2/ibmix-aem-sonar-rules-1.2.jar
 
 1.1.description=Initial release of the IBM iX AEM rules plugin
 1.1.sqVersions=[9.0,LATEST]


### PR DESCRIPTION
Version 1.2 release of the ibmix-aem-sonar-rules plugin