### PR TITLE
Release AuthAAD 1.3.2

### DIFF
--- a/authaad.properties
+++ b/authaad.properties
@@ -2,20 +2,26 @@ name=Azure Active Directory Authentication for SonarQube
 category=Integration
 description=Allows the use of Azure Active Directory as an authentication source for SonarQube.
 homepageUrl=https://github.com/hkamel/sonar-auth-aad
-archivedVersions=1.2.0
-publicVersions=1.3.1
+archivedVersions=1.2.0,1.3.1
+publicVersions=1.3.2
 
 defaults.mavenGroupId=org.almrangers.auth.aad
 defaults.mavenArtifactId=sonar-auth-aad-plugin
 
+1.3.2.description=Updates commons-text to fix CVE-2022-42889.
+1.3.2.sqVersions=[8.9,LATEST]
+1.3.2.date=2022-11-11
+1.3.2.changelogUrl=https://github.com/hkamel/sonar-auth-aad/releases/tag/1.3.2
+1.3.2.downloadUrl=https://github.com/hkamel/sonar-auth-aad/releases/download/1.3.2/sonar-auth-aad-plugin-1.3.2.jar
+
 1.3.1.description=Client credential flow, updated settings layout, support for localization.
-1.3.1.sqVersions=[8.9, LATEST]
+1.3.1.sqVersions=[8.9,9.7.*]
 1.3.1.date=2022-08-02
 1.3.1.changelogUrl=https://github.com/hkamel/sonar-auth-aad/releases/tag/1.3.1
 1.3.1.downloadUrl=https://github.com/hkamel/sonar-auth-aad/releases/download/1.3.1/sonar-auth-aad-plugin-1.3.1.jar
 
 1.2.0.description=Group sync enhancements including transitive members. Code cleanup.
-1.2.0.sqVersions=[8.9, 9.5]
+1.2.0.sqVersions=[8.9,9.5]
 1.2.0.date=2020-02-05
 1.2.0.changelogUrl=https://github.com/hkamel/sonar-auth-aad/releases/tag/1.2.0
 1.2.0.downloadUrl=https://github.com/hkamel/sonar-auth-aad/releases/download/1.2.0/sonar-auth-aad-plugin-1.2.0.jar


### PR DESCRIPTION
This release doesn't change any plugin code. It updates a dependency to resolve a CVE.

SonarCloud dashboard: https://sonarcloud.io/project/overview?id=org.almrangers.auth.aad%3Asonar-auth-aad-plugin