### PR TITLE
Declaration of release 3.0.2 (support for SQ 9.7+)

### DIFF
--- a/apigee.properties
+++ b/apigee.properties
@@ -2,14 +2,20 @@ category=External Analyzers
 description=Adds XML rules test Apigee apiproxies.
 homepageUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin
 archivedVersions=
-publicVersions=3.0.1
+publicVersions=3.0.1,3.0.2
 
 
 defaults.mavenGroupId=com.arkea.satd.sonar.apigee
 defaults.mavenArtifactId=sonar-apigee-plugin
 
+3.0.2.description=Support for SQ 9.7+
+3.0.2.sqVersions=[9.7,LATEST]
+3.0.2.date=2022-12-15
+3.0.2.changelogUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/tag/v3.0.2
+3.0.2.downloadUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/download/v3.0.2/sonar-apigee-plugin-3.0.2.jar
+
 3.0.1.description=Support for SQ 8.8+
-3.0.1.sqVersions=[8.9,LATEST]
+3.0.1.sqVersions=[8.9,9.6.*]
 3.0.1.date=2021-05-28
 3.0.1.changelogUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/tag/v3.0.1
 3.0.1.downloadUrl=https://github.com/CreditMutuelArkea/sonar-apigee-plugin/releases/download/v3.0.1/sonar-apigee-plugin-3.0.1.jar


### PR DESCRIPTION
Declare release 3.0.2 for SQ 9.7+  (fix for https://github.com/CreditMutuelArkea/sonar-apigee-plugin/issues/15 )
Keep 3.0.1 for older SQ versions
