### PR TITLE
sonar-l10n-zh-plugin-9.8

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=
-publicVersions=8.9,9.0,9.1,9.2,9.3,9.4,9.5,9.6,9.7
+publicVersions=8.9,9.0,9.1,9.2,9.3,9.4,9.5,9.6,9.7,9.8
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+9.8.description=Support SonarQube 9.8
+9.8.sqVersions=[9.8,LATEST]
+9.8.date=2022-12-17
+9.8.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-9.8
+9.8.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-9.8/sonar-l10n-zh-plugin-9.8.jar
+
 9.7.description=Support SonarQube 9.7
-9.7.sqVersions=[9.7,LATEST]
+9.7.sqVersions=[9.7,9.7.*]
 9.7.date=2022-10-19
 9.7.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-9.7
 9.7.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-9.7/sonar-l10n-zh-plugin-9.7.jar


### PR DESCRIPTION
Hi,

sonar-l10n-zh-plugin-9.8 has been released.

The main changes is support SonarQube 9.8.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-9.8/sonar-l10n-zh-plugin-9.8.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards
