### PR TITLE
sonar-l10n-fr-plugin-9.8.0

### DIFF
--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -1,14 +1,20 @@
 category=Localization
 description=Language Pack for French
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-fr
-publicVersions=1.15.1
+publicVersions=1.15.1,9.8.0
 archivedVersions=
 
-defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
+defaults.mavenGroupId=org.sonarqube.l10n.fr
 defaults.mavenArtifactId=sonar-l10n-fr-plugin
 
 1.15.1.description=Support SonarQube 6.7.3+
-1.15.1.sqVersions=[8.9,LATEST]
+1.15.1.sqVersions=[8.9,8.9.*]
 1.15.1.date=2018-08-28
 1.15.1.downloadUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/download/1.15.1/sonar-l10n-fr-plugin-1.15.1.jar
 1.15.1.changelogUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/tag/1.15.1
+
+9.8.0.description=Support SonarQube 9.8+
+9.8.0.sqVersions=[9.8,LATEST]
+9.8.0.date=2023-01-04
+9.8.0.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.8.0/sonar-l10n-fr-plugin-9.8.0.jar
+9.8.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.0

--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -8,7 +8,7 @@ defaults.mavenGroupId=org.sonarqube.l10n.fr
 defaults.mavenArtifactId=sonar-l10n-fr-plugin
 
 1.15.1.description=Support SonarQube 6.7.3+
-1.15.1.sqVersions=[8.9,8.9.*]
+1.15.1.sqVersions=[8.9,9.7.*]
 1.15.1.date=2018-08-28
 1.15.1.downloadUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/download/1.15.1/sonar-l10n-fr-plugin-1.15.1.jar
 1.15.1.changelogUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/tag/1.15.1

--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -9,6 +9,7 @@ defaults.mavenArtifactId=sonar-l10n-fr-plugin
 
 1.15.1.description=Support SonarQube 6.7.3+
 1.15.1.sqVersions=[8.9,9.7.*]
+1.15.1.mavenGroupId=org.codehaus.sonar-plugins.l10n
 1.15.1.date=2018-08-28
 1.15.1.downloadUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/download/1.15.1/sonar-l10n-fr-plugin-1.15.1.jar
 1.15.1.changelogUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/tag/1.15.1


### PR DESCRIPTION
Hi,

sonar-l10n-fr-plugin-9.8.0 has been released.

NB: Repository has changed of ownership (from https://github.com/ZoeThivet/sonar-l10n-fr to https://github.com/jycr/sonar-l10n-fr)

The main changes is support SonarQube 9.8.

The Download link and release notes: https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.0

The SonarCloud: https://sonarcloud.io/project/overview?id=jycr_sonar-l10n-fr

Please update the market place.

Thank you

Regards