### PR TITLE
update SonarScanner for Gradle version numbers to include build number

### DIFF
--- a/scannergradle.properties
+++ b/scannergradle.properties
@@ -6,18 +6,18 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/
 issueTrackerUrl=https://jira.sonarsource.com/browse/SONARGRADL/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-gradle
-archivedVersions=2.8,3.0,3.1,3.1.1,3.2,3.3,3.4
-publicVersions=3.5
+archivedVersions=2.8,3.0,3.1,3.1.1,3.2,3.3,3.4.0.2513
+publicVersions=3.5.0.2730
 
-3.5.description=New 'sonar' task name and better support for Android projects
-3.5.date=2022-10-27
-3.5.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010137%20AND%20fixVersion%20%3D%2012396
-3.5.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube
+3.5.0.2730.description=New 'sonar' task name and better support for Android projects
+3.5.0.2730.date=2022-10-27
+3.5.0.2730.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010137%20AND%20fixVersion%20%3D%2012396
+3.5.0.2730.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube
 
-3.4.description=Support Gradle 8 and Java 17, increase socket connect timeout to 30s
-3.4.date=2022-06-08
-3.4.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10974&version=16991
-3.4.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube
+3.4.0.2513.description=Support Gradle 8 and Java 17, increase socket connect timeout to 30s
+3.4.0.2513.date=2022-06-08
+3.4.0.2513.changelogUrl=https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10974&version=16991
+3.4.0.2513.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube
 
 3.3.description=Support Android dynamic features modules
 3.3.date=2021-06-10


### PR DESCRIPTION
The SQ documentation website pulls content from this file and displays it at the [top of the SonarScanner for Gradle page](https://docs.sonarqube.org/latest/analyzing-source-code/scanners/sonarscanner-for-gradle/). It has been reported that the build numbers must be included to prevent build ID errors.