### PR TITLE
sonar-l10n-fr-plugin-9.8.1

### DIFF
--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -15,7 +15,7 @@ defaults.mavenArtifactId=sonar-l10n-fr-plugin
 1.15.1.changelogUrl=https://github.com/ZoeThivet/sonar-l10n-fr/releases/tag/1.15.1
 
 9.8.0.description=Support SonarQube 9.8+
-9.8.0.sqVersions=[9.8,LATEST]
+9.8.0.sqVersions=[9.8,9.8]
 9.8.0.date=2023-01-04
 9.8.0.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.8.0/sonar-l10n-fr-plugin-9.8.0.jar
 9.8.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.0

--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -1,8 +1,8 @@
 category=Localization
 description=Language Pack for French
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-fr
-publicVersions=1.15.1,9.8.0
-archivedVersions=
+publicVersions=1.15.1,9.8.1
+archivedVersions=9.8.0
 
 defaults.mavenGroupId=org.sonarqube.l10n.fr
 defaults.mavenArtifactId=sonar-l10n-fr-plugin
@@ -19,3 +19,9 @@ defaults.mavenArtifactId=sonar-l10n-fr-plugin
 9.8.0.date=2023-01-04
 9.8.0.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.8.0/sonar-l10n-fr-plugin-9.8.0.jar
 9.8.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.0
+
+9.8.1.description=Fix misleading translations and epicene writing
+9.8.1.sqVersions=[9.8,LATEST]
+9.8.1.date=2023-01-16
+9.8.1.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.8.1/sonar-l10n-fr-plugin-9.8.1.jar
+9.8.1.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.1


### PR DESCRIPTION
Hi,

sonar-l10n-fr-plugin-9.8.1 has been released.

Changes:

- Fix misleading translations
- Implement epicene writing

The Download link and release notes: https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.1

The SonarCloud: https://sonarcloud.io/project/overview?id=jycr_sonar-l10n-fr

Please update the market place.

Thank you

Regards