### PR TITLE
Update sonar-dependency-check-plugin to 3.1.0

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,10 +1,16 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.7,2.0.8,3.0.0
-publicVersions=3.0.1
+archivedVersions=2.0.7,2.0.8,3.0.0,3.0.1
+publicVersions=3.1.0
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
+
+3.1.0.description=Support dependency-check 8.0.0
+3.1.0.sqVersions=[8.9.7, LATEST]
+3.1.0.date=2023-02-23
+3.1.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.1.0
+3.1.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.1.0/sonar-dependency-check-plugin-3.1.0.jar
 
 3.0.1.description=Restore JDK8 compatibility
 3.0.1.sqVersions=[8.9.7, LATEST]

--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=sonar-dependency-check-plugin
 3.1.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.1.0/sonar-dependency-check-plugin-3.1.0.jar
 
 3.0.1.description=Restore JDK8 compatibility
-3.0.1.sqVersions=[8.9.7, LATEST]
+3.0.1.sqVersions=[8.9.7, 9.9]
 3.0.1.date=2022-02-24
 3.0.1.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.0.1
 3.0.1.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.0.1/sonar-dependency-check-plugin-3.0.1.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 3.1.0, please add it to the marketplace.
Thanks in advance!

  A short description of the change can be found in the [SonarCommunity forum](https://community.sonarsource.com/t/new-release-sonar-dependency-check-plugin-3-1-0/84683).