### PR TITLE
Add ecoCode-mobile SonarQube plugin for Android platforms

### DIFF
--- a/ecocode-android.properties
+++ b/ecocode-android.properties
@@ -1,0 +1,13 @@
+category=External Analysers
+description=Targets Android mobile platforms code: provides static code analyzers to highlight code structures that may have a negative ecological impact (energy over-consumption, "fatware", shortening devices' lifespan, etc.).
+homepageUrl=https://github.com/green-code-initiative/ecoCode-mobile
+publicVersions=0.1.0
+
+defaults.mavenGroupId=io.ecocode
+defaults.mavenArtifactId=ecocode-android
+
+0.1.0.description=Initial Marketplace publication of plugin for SonarQube 9.4.+ LTS
+0.1.0.sqVersions=[9.4,LATEST]
+0.1.0.date=2023-01-03
+0.1.0.downloadUrl=https://github.com/green-code-initiative/ecoCode-mobile/releases/download/0.1.0/ecocode-android-0.1.0.jar
+0.1.0.changelogUrl=https://github.com/green-code-initiative/ecoCode-mobile/releases/tag/0.1.0


### PR DESCRIPTION
This PR add a plugin (for Android code) from https://github.com/green-code-initiative/ecoCode (see: https://github.com/green-code-initiative/ecoCode-mobile/tree/main/android-plugin).

Description from project:

> Mobile apps running on top of battery-limited devices are more than others concerned by the reduction of their environmental footprint. Hence, we created ecoCode mobile, the version of ecoCode project fully dedicated to mobile platforms. It provides static code analyzers to highlight code structures that may have a negative ecological impact: energy over-consumption, "fatware", shortening devices' lifespan, etc.

> ecoCode mobile is based on evolving catalogs of [best practices](https://github.com/cnumr/best-practices-mobile), for Android _[...]_. A SonarQube plugin then implement these catalogs as rules for scanning your projects. To learn more, take a look at the [complete presentation](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/docs/resources/devfest-2022.pdf) (in french) or the [presentation in a nutshell](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/docs/resources/apidays-2022.pdf) (in english).

[SonarCloud: green-code-initiative_ecoCode](https://sonarcloud.io/project/overview?id=green-code-initiative_ecoCode-mobile)