### PR TITLE
Update sonar-dependency-check-plugin to 4.0.0

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,13 +1,19 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.7,2.0.8,3.0.0,3.0.1
-publicVersions=3.1.0
+archivedVersions=2.0.7,2.0.8,3.0.0,3.0.1,3.1.0
+publicVersions=4.0.0
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
+4.0.0.description=Support SonarQube 10
+4.0.0.sqVersions=[9.9.1, LATEST]
+4.0.0.date=2023-05-16
+4.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/4.0.0
+4.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/4.0.0/sonar-dependency-check-plugin-4.0.0.jar
+
 3.1.0.description=Support dependency-check 8.0.0
-3.1.0.sqVersions=[8.9.7, LATEST]
+3.1.0.sqVersions=[8.9.7, 9.9]
 3.1.0.date=2023-02-23
 3.1.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.1.0
 3.1.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.1.0/sonar-dependency-check-plugin-3.1.0.jar

--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -7,13 +7,13 @@ defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
 4.0.0.description=Support SonarQube 10
-4.0.0.sqVersions=[9.9.1, LATEST]
+4.0.0.sqVersions=[9.9, LATEST]
 4.0.0.date=2023-05-16
 4.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/4.0.0
 4.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/4.0.0/sonar-dependency-check-plugin-4.0.0.jar
 
 3.1.0.description=Support dependency-check 8.0.0
-3.1.0.sqVersions=[8.9.7, 9.9]
+3.1.0.sqVersions=[8.9.7, 9.9.*]
 3.1.0.date=2023-02-23
 3.1.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.1.0
 3.1.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.1.0/sonar-dependency-check-plugin-3.1.0.jar

--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -7,31 +7,31 @@ defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
 
 4.0.0.description=Support SonarQube 10
-4.0.0.sqVersions=[9.9, LATEST]
+4.0.0.sqVersions=[9.9,LATEST]
 4.0.0.date=2023-05-16
 4.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/4.0.0
 4.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/4.0.0/sonar-dependency-check-plugin-4.0.0.jar
 
 3.1.0.description=Support dependency-check 8.0.0
-3.1.0.sqVersions=[8.9.7, 9.9.*]
+3.1.0.sqVersions=[8.9.7,9.9.*]
 3.1.0.date=2023-02-23
 3.1.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.1.0
 3.1.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.1.0/sonar-dependency-check-plugin-3.1.0.jar
 
 3.0.1.description=Restore JDK8 compatibility
-3.0.1.sqVersions=[8.9.7, 9.9]
+3.0.1.sqVersions=[8.9.7,9.9]
 3.0.1.date=2022-02-24
 3.0.1.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.0.1
 3.0.1.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.0.1/sonar-dependency-check-plugin-3.0.1.jar
 
 3.0.0.description=Update Plugin to SonarQube 8 API and deprecate XML-Reports
-3.0.0.sqVersions=[8.9.7, 9.3]
+3.0.0.sqVersions=[8.9.7,9.3]
 3.0.0.date=2022-02-10
 3.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/3.0.0
 3.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.0.0/sonar-dependency-check-plugin-3.0.0.jar
 
 2.0.8.description=Maintenance version with library updates
-2.0.8.sqVersions=[8.9, 9.3]
+2.0.8.sqVersions=[8.9,9.3]
 2.0.8.date=2021-05-31
 2.0.8.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/2.0.8
 2.0.8.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.8/sonar-dependency-check-plugin-2.0.8.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 4.0.0, please add it to the marketplace.
Thanks in advance!

SonarCloud-Dashboard: https://sonarcloud.io/dashboard?id=dependency-check_dependency-check-sonar-plugin