### PR TITLE
sonar-l10n-fr-plugin-9.9.1

### DIFF
--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -1,8 +1,8 @@
 category=Localization
 description=Language Pack for French
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-fr
-publicVersions=1.15.1,9.8.1,9.9.0
-archivedVersions=9.8.0
+publicVersions=1.15.1,9.8.1,9.9.1
+archivedVersions=9.8.0,9.9.0
 
 defaults.mavenGroupId=org.sonarqube.l10n.fr
 defaults.mavenArtifactId=sonar-l10n-fr-plugin
@@ -27,7 +27,13 @@ defaults.mavenArtifactId=sonar-l10n-fr-plugin
 9.8.1.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.8.1
 
 9.9.0.description=Support SonarQube 9.9+
-9.9.0.sqVersions=[9.9,LATEST]
+9.9.0.sqVersions=[9.9,9.9.*]
 9.9.0.date=2023-03-22
 9.9.0.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.9.0/sonar-l10n-fr-plugin-9.9.0.jar
 9.9.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.0
+
+9.9.1.description=Fixes misleading translations and uses right apostrophe quotation mark
+9.9.1.sqVersions=[9.9,LATEST]
+9.9.1.date=2023-05-31
+9.9.1.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.9.1/sonar-l10n-fr-plugin-9.9.1.jar
+9.9.1.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.1


### PR DESCRIPTION
Hi,

sonar-l10n-fr-plugin-9.9.1 has been released.

Changes:

* Fixes misleading translations
* Improves "CI" translations
* Uses right apostrophe quotation mark

The Download link and release notes: https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.1

The SonarCloud: https://sonarcloud.io/project/overview?id=jycr_sonar-l10n-fr

Please update the market place.

Thank you

Regards