### PR TITLE
sonar-l10n-fr-plugin-10.0.0

### DIFF
--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -1,8 +1,8 @@
 category=Localization
 description=Language Pack for French
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-fr
-publicVersions=1.15.1,9.8.1,9.9.1
-archivedVersions=9.8.0,9.9.0
+publicVersions=1.15.1,9.8.1,9.9.2,10.0.0
+archivedVersions=9.8.0,9.9.0,9.9.1
 
 defaults.mavenGroupId=org.sonarqube.l10n.fr
 defaults.mavenArtifactId=sonar-l10n-fr-plugin
@@ -33,7 +33,19 @@ defaults.mavenArtifactId=sonar-l10n-fr-plugin
 9.9.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.0
 
 9.9.1.description=Fixes misleading translations and uses right apostrophe quotation mark
-9.9.1.sqVersions=[9.9,LATEST]
+9.9.1.sqVersions=[9.9,9.9.*]
 9.9.1.date=2023-05-31
 9.9.1.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.9.1/sonar-l10n-fr-plugin-9.9.1.jar
 9.9.1.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.1
+
+9.9.2.description=Uses right quotation mark, fixes misleading translations, changes "demande de changement" by "Demande de Fusion" and "webhook" by "Notification Web"
+9.9.2.sqVersions=[9.9,LATEST]
+9.9.2.date=2023-06-02
+9.9.2.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.9.2/sonar-l10n-fr-plugin-9.9.2.jar
+9.9.2.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.2
+
+10.0.0.description=Support SonarQube 10.0
+10.0.0.sqVersions=[10.0,LATEST]
+10.0.0.date=2023-06-02
+10.0.0.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/10.0.0/sonar-l10n-fr-plugin-10.0.0.jar
+10.0.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/10.0.0

--- a/l10nfr.properties
+++ b/l10nfr.properties
@@ -33,13 +33,13 @@ defaults.mavenArtifactId=sonar-l10n-fr-plugin
 9.9.0.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.0
 
 9.9.1.description=Fixes misleading translations and uses right apostrophe quotation mark
-9.9.1.sqVersions=[9.9,9.9.*]
+9.9.1.sqVersions=[9.9,10.0]
 9.9.1.date=2023-05-31
 9.9.1.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.9.1/sonar-l10n-fr-plugin-9.9.1.jar
 9.9.1.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.1
 
 9.9.2.description=Uses right quotation mark, fixes misleading translations, changes "demande de changement" by "Demande de Fusion" and "webhook" by "Notification Web"
-9.9.2.sqVersions=[9.9,LATEST]
+9.9.2.sqVersions=[9.9,9.9.*]
 9.9.2.date=2023-06-02
 9.9.2.downloadUrl=https://github.com/jycr/sonar-l10n-fr/releases/download/9.9.2/sonar-l10n-fr-plugin-9.9.2.jar
 9.9.2.changelogUrl=https://github.com/jycr/sonar-l10n-fr/releases/tag/9.9.2


### PR DESCRIPTION
Hi,

sonar-l10n-fr-plugin-10.0.0 has been released.

Changes:

* Support SonarQube 10.0

The Download link and release notes: https://github.com/jycr/sonar-l10n-fr/releases/tag/10.0.0

The SonarCloud: https://sonarcloud.io/project/overview?id=jycr_sonar-l10n-fr

Please update the market place.

Thank you

Regards