### PR TITLE
Update scannergradle.properties

### DIFF
--- a/scannergradle.properties
+++ b/scannergradle.properties
@@ -1,5 +1,5 @@
 category=Scanners
-name=SonarScanner for Graddle
+name=SonarScanner for Gradle
 license=GNU LGPL 3
 organization=SonarSource
 organizationUrl=https://www.sonarsource.com
@@ -7,12 +7,12 @@ homepageUrl=https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gra
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SONARGRADL/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-gradle
 archivedVersions=2.8,3.0,3.1,3.1.1,3.2,3.3,3.4.0.2513,3.5.0.2730,4.0.0.2929
-publicVersions=4.1.0.3113
+publicVersions=4.2.1.3168
 
-4.1.0.3113.description=Support for Kotlin Multiplatform and 'sonar.java.enablePreview' property, Java 11+ required
-4.1.0.3113.date=2023-05-26
-4.1.0.3113.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010137%20AND%20fixVersion%20%3D%2014114
-4.1.0.3113.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube
+4.2.1.3168.description=Support for Kotlin Multiplatform and 'sonar.java.enablePreview' property, Java 11+ required
+4.2.1.3168.date=2023-06-12
+4.2.1.3168.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010137%20AND%20fixVersion%20%3D%2014114
+4.2.1.3168.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube
 
 4.0.0.2929.description=Support for Gradle 8
 4.0.0.2929.date=2023-02-17


### PR DESCRIPTION
Scanner for Gradle 4.2.1.3168

Remove 4.1 because it contains bugs preventing scanning in some cases.