### PR TITLE
1c bsl community plugin. New version 1.12.0

### DIFF
--- a/communitybsl.properties
+++ b/communitybsl.properties
@@ -1,14 +1,20 @@
 category=Languages
 description=Code Analyzer for 1C (BSL)
 homepageUrl=https://1c-syntax.github.io/sonar-bsl-plugin-community/en
-archivedVersions=1.9.0,1.10.0
-publicVersions=1.11.0
+archivedVersions=1.9.0,1.10.0,1.11.0
+publicVersions=1.12.0
 
 defaults.mavenGroupId=com.github.1c-syntax
 defaults.mavenArtifactId=sonar-communitybsl-plugin
 
+1.12.0.description=9 new rules, bug fixes, optimize
+1.12.0.sqVersions=[8.9,LATEST]
+1.12.0.date=2023-06-23
+1.12.0.changelogUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/tag/v1.12.0
+1.12.0.downloadUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/download/v1.12.0/sonar-communitybsl-plugin-1.12.0.jar
+
 1.11.0.description=13 new rules, bug fixes, support new reporters
-1.11.0.sqVersions=[8.9,LATEST]
+1.11.0.sqVersions=[8.9,9.9.*]
 1.11.0.date=2022-05-25
 1.11.0.changelogUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/tag/v1.11.0
 1.11.0.downloadUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/download/v1.11.0/sonar-communitybsl-plugin-1.11.0.jar


### PR DESCRIPTION
New rules, fixes.


SonarQube page https://sonarcloud.io/summary/new_code?id=1c-syntax_sonar-bsl-plugin-community