### PR TITLE
Upgrade ecoCode plugins to 1.3.0 for languages: Java, PHP, Python

### DIFF
--- a/ecocodejava.properties
+++ b/ecocodejava.properties
@@ -1,13 +1,21 @@
 category=External Analysers
 description=Provide a list of static code analyzers (for Java language) to highlight code structures that may have a negative ecological impact: energy and resources over-consumption, "fatware", shortening terminals' lifespan, etc.
 homepageUrl=https://github.com/green-code-initiative/ecoCode
-publicVersions=1.2.1
+publicVersions=1.3.0
+archivedVersions=1.2.1
+
 
 defaults.mavenGroupId=io.ecocode
 defaults.mavenArtifactId=ecocode-java-plugin
 
 1.2.1.description=Initial Marketplace publication of plugin for SonarQube 9.9.+ LTS
-1.2.1.sqVersions=[9.9,LATEST]
+1.2.1.sqVersions=[9.9,10.1]
 1.2.1.date=2023-04-14
 1.2.1.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.2.1/ecocode-java-plugin-1.2.1.jar
 1.2.1.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.2.1
+
+1.3.0.description=Update rules tags ; upgrade librairies to SonarQube 10.0.0 ; clean-up plugins and dependencies
+1.3.0.sqVersions=[9.9,LATEST]
+1.3.0.date=2023-07-04
+1.3.0.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.3.0/ecocode-java-plugin-1.3.0.jar
+1.3.0.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.3.0

--- a/ecocodephp.properties
+++ b/ecocodephp.properties
@@ -1,13 +1,20 @@
 category=External Analysers
 description=Provide a list of static code analyzers (for PHP language) to highlight code structures that may have a negative ecological impact: energy and resources over-consumption, "fatware", shortening terminals' lifespan, etc.
 homepageUrl=https://github.com/green-code-initiative/ecoCode
-publicVersions=1.2.1
+publicVersions=1.3.0
+archivedVersions=1.2.1
 
 defaults.mavenGroupId=io.ecocode
 defaults.mavenArtifactId=ecocode-php-plugin
 
 1.2.1.description=Initial Marketplace publication of plugin for SonarQube 9.9.+ LTS
-1.2.1.sqVersions=[9.9,LATEST]
+1.2.1.sqVersions=[9.9,10.1]
 1.2.1.date=2023-04-14
 1.2.1.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.2.1/ecocode-php-plugin-1.2.1.jar
 1.2.1.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.2.1
+
+1.3.0.description=Updates rules tags ; adds rule (EC3) ; upgrades librairies to SonarQube 10.0.0 ; clean-up plugins and dependencies
+1.3.0.sqVersions=[9.9,LATEST]
+1.3.0.date=2023-07-04
+1.3.0.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.3.0/ecocode-php-plugin-1.3.0.jar
+1.3.0.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.3.0

--- a/ecocodepython.properties
+++ b/ecocodepython.properties
@@ -1,13 +1,20 @@
 category=External Analysers
 description=Provide a list of static code analyzers (for Python language) to highlight code structures that may have a negative ecological impact: energy and resources over-consumption, "fatware", shortening terminals' lifespan, etc.
 homepageUrl=https://github.com/green-code-initiative/ecoCode
-publicVersions=1.2.1
+publicVersions=1.3.0
+archivedVersions=1.2.1
 
 defaults.mavenGroupId=io.ecocode
 defaults.mavenArtifactId=ecocode-python-plugin
 
 1.2.1.description=Initial Marketplace publication of plugin for SonarQube 9.9.+ LTS
-1.2.1.sqVersions=[9.9,LATEST]
+1.2.1.sqVersions=[9.9,10.1]
 1.2.1.date=2023-04-14
 1.2.1.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.2.1/ecocode-python-plugin-1.2.1.jar
 1.2.1.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.2.1
+
+1.3.0.description=Updates rules tags ; adds rules (EC10, EC66, EC203, EC404) ; upgrade librairies to SonarQube 10.0.0 ; clean-up plugins and dependencies
+1.3.0.sqVersions=[9.9,LATEST]
+1.3.0.date=2023-07-04
+1.3.0.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.3.0/ecocode-python-plugin-1.3.0.jar
+1.3.0.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.3.0


### PR DESCRIPTION
Hi,

ecoCode plugins 1.3.0 (for languages: Java PHP, Python) have been released.

Changes:

* Support SonarQube 10.0
* https://github.com/green-code-initiative/ecoCode/issues/191
* Adds rules for Python language:
  * `EC10` : https://github.com/green-code-initiative/ecoCode/pull/190
  * `EC66` : https://github.com/green-code-initiative/ecoCode/issues/108
  * `EC203` : https://github.com/green-code-initiative/ecoCode/pull/192
  * `EC404` : https://github.com/green-code-initiative/ecoCode/issues/127
* Adds rules for PHP language:
  * `EC3` : https://github.com/green-code-initiative/ecoCode/issues/109


The corresponding SonarCloud project: https://sonarcloud.io/summary/new_code?id=green-code-initiative_ecoCode&pullRequest=206

Please update the market place.

Thank you

Regards