### PR TITLE
support sonarqube-10.1

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -14,7 +14,7 @@ defaults.mavenArtifactId=sonar-l10n-zh-plugin
 10.1.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.1/sonar-l10n-zh-plugin-10.1.jar
 
 10.0.description=Support SonarQube 10.0
-10.0.sqVersions=[10.0,10.1.*]
+10.0.sqVersions=10.0
 10.0.date=2023-04-05
 10.0.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.0
 10.0.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.0/sonar-l10n-zh-plugin-10.0.jar

--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -14,7 +14,7 @@ defaults.mavenArtifactId=sonar-l10n-zh-plugin
 10.1.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.1/sonar-l10n-zh-plugin-10.1.jar
 
 10.0.description=Support SonarQube 10.0
-10.0.sqVersions=[10.0,10.0.*]
+10.0.sqVersions=[10.0,10.1.*]
 10.0.date=2023-04-05
 10.0.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.0
 10.0.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.0/sonar-l10n-zh-plugin-10.0.jar

--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=
-publicVersions=8.9,9.0,9.1,9.2,9.3,9.4,9.5,9.6,9.7,9.8,9.9,10.0
+publicVersions=8.9,9.0,9.1,9.2,9.3,9.4,9.5,9.6,9.7,9.8,9.9,10.0,10.1
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+10.1.description=Support SonarQube 10.1
+10.1.sqVersions=[10.1,LATEST]
+10.1.date=2023-07-07
+10.1.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.1
+10.1.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.1/sonar-l10n-zh-plugin-10.1.jar
+
 10.0.description=Support SonarQube 10.0
-10.0.sqVersions=[10.0,LATEST]
+10.0.sqVersions=[10.0,10.0.*]
 10.0.date=2023-04-05
 10.0.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.0
 10.0.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.0/sonar-l10n-zh-plugin-10.0.jar


### PR DESCRIPTION
Hi,

sonar-l10n-zh-plugin-10.1 has been released.

The main changes is support SonarQube 10.1.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.1/sonar-l10n-zh-plugin-10.1.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards