### PR TITLE
sonar-l10n-zh-plugin-10.3

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=
-publicVersions=8.9,9.0,9.1,9.2,9.3,9.4,9.5,9.6,9.7,9.8,9.9,10.0,10.1,10.2
+publicVersions=8.9,9.0,9.1,9.2,9.3,9.4,9.5,9.6,9.7,9.8,9.9,10.0,10.1,10.2,10.3
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+10.3.description=Support SonarQube 10.3
+10.3.sqVersions=[10.3,LATEST]
+10.3.date=2023-11-20
+10.3.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.3
+10.3.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.3/sonar-l10n-zh-plugin-10.3.jar
+
 10.2.description=Support SonarQube 10.2
-10.2.sqVersions=[10.2,LATEST]
+10.2.sqVersions=[10.2,10.2.*]
 10.2.date=2023-09-08
 10.2.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.2
 10.2.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.2/sonar-l10n-zh-plugin-10.2.jar


### PR DESCRIPTION
Hi,

sonar-l10n-zh-plugin-10.3 has been released.

The main changes is support SonarQube 10.3.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.3/sonar-l10n-zh-plugin-10.3.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards
