### PR TITLE
Upgrade JAVA ecoCode plugins to 1.4.2

### DIFF
--- a/ecocodejava.properties
+++ b/ecocodejava.properties
@@ -1,9 +1,8 @@
 category=External Analysers
 description=Provide a list of static code analyzers (for Java language) to highlight code structures that may have a negative ecological impact: energy and resources over-consumption, "fatware", shortening terminals' lifespan, etc.
 homepageUrl=https://github.com/green-code-initiative/ecoCode
-publicVersions=1.3.0
-archivedVersions=1.2.1
-
+publicVersions=1.4.2
+archivedVersions=1.3.0
 
 defaults.mavenGroupId=io.ecocode
 defaults.mavenArtifactId=ecocode-java-plugin
@@ -15,7 +14,13 @@ defaults.mavenArtifactId=ecocode-java-plugin
 1.2.1.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.2.1
 
 1.3.0.description=Update rules tags ; upgrade librairies to SonarQube 10.0.0 ; clean-up plugins and dependencies
-1.3.0.sqVersions=[9.9,LATEST]
+1.3.0.sqVersions=[9.9,10.1]
 1.3.0.date=2023-07-04
 1.3.0.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.3.0/ecocode-java-plugin-1.3.0.jar
 1.3.0.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.3.0
+
+1.4.2.description=A lot of corrections and improvements (please check CHANGELOG)
+1.4.2.sqVersions=[9.4,9.8,9.9,10.0,10.1]
+1.4.2.date=2023-12-05
+1.4.2.downloadUrl=https://github.com/green-code-initiative/ecoCode/releases/download/1.4.2/ecocode-java-plugin-1.4.2.jar
+1.4.2.changelogUrl=https://github.com/green-code-initiative/ecoCode/releases/tag/1.4.2


### PR DESCRIPTION
Hi,

ecoCode JAVA plugin 1.4.2 has been released.

Changes from last SonarQube marketplace integration (1.3.0), please check following changelogs : 

- from 1.3.0 to 1.3.1 : https://github.com/green-code-initiative/ecoCode/releases/tag/1.3.1
- from 1.3.1 to 1.4.0 : https://github.com/green-code-initiative/ecoCode/releases/tag/1.4.0
- from 1.4.0 to 1.4.1 : https://github.com/green-code-initiative/ecoCode/releases/tag/1.4.1
- from 1.4.1 to 1.4.2 : https://github.com/green-code-initiative/ecoCode/releases/tag/1.4.2

The corresponding SonarCloud project: https://sonarcloud.io/project/overview?id=green-code-initiative_ecoCode

Please update the market place.

Thank you

Regards