### PR TITLE
Update sonar-dependency-check-plugin to 4.0.1

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -1,10 +1,16 @@
 category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
-archivedVersions=2.0.7,2.0.8,3.0.0,3.0.1,3.1.0
-publicVersions=4.0.0
+archivedVersions=2.0.7,2.0.8,3.0.0,3.0.1,3.1.0,4.0.0
+publicVersions=4.0.1
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
+
+4.0.1.description=Support dependency-check 9.0.2
+4.0.1.sqVersions=[9.9,LATEST]
+4.0.1.date=2023-12-12
+4.0.1.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/4.0.1
+4.0.1.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/4.0.1/sonar-dependency-check-plugin-4.0.1.jar
 
 4.0.0.description=Support SonarQube 10
 4.0.0.sqVersions=[9.9,LATEST]

--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -13,7 +13,7 @@ defaults.mavenArtifactId=sonar-dependency-check-plugin
 4.0.1.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/4.0.1/sonar-dependency-check-plugin-4.0.1.jar
 
 4.0.0.description=Support SonarQube 10
-4.0.0.sqVersions=[9.9,LATEST]
+4.0.0.sqVersions=[9.9,10.3]
 4.0.0.date=2023-05-16
 4.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/4.0.0
 4.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/4.0.0/sonar-dependency-check-plugin-4.0.0.jar


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 4.0.1, please add it to the marketplace.
Thanks in advance!

SonarCloud-Dashboard: https://sonarcloud.io/dashboard?id=dependency-check_dependency-check-sonar-plugin