### PR TITLE
OpenEdge plugin 2.24.3

### DIFF
--- a/openedge.properties
+++ b/openedge.properties
@@ -2,7 +2,7 @@ category=Languages
 description=Code Analyzer for OpenEdge
 homepageUrl=https://github.com/Riverside-Software/sonar-openedge
 archivedVersions=2.19.2,2.24.2
-publicVersions=
+publicVersions=2.24.3
 
 defaults.mavenGroupId=eu.rssw.sonar.openedge
 defaults.mavenArtifactId=sonar-openedge-plugin
@@ -14,5 +14,12 @@ defaults.mavenArtifactId=sonar-openedge-plugin
 2.19.2.downloadUrl=https://github.com/Riverside-Software/sonar-openedge/releases/download/V2.19.1/sonar-openedge-plugin-2.19.2.jar
 
 2.24.2.description=Version 2.24.2
-2.24.2.sqVersions=[9.9,LATEST]
+2.24.2.sqVersions=[9.9,10.4]
 2.24.2.date=2023-12-10
+
+2.24.3.description=Version 2.24.3
+2.24.3.sqVersions=[9.9,LATEST]
+2.24.3.date=2024-01-26
+2.24.3.changelogUrl=https://github.com/Riverside-Software/sonar-openedge/releases/tag/V2.24.1
+2.24.3.downloadUrl=https://github.com/Riverside-Software/sonar-openedge/releases/download/V2.24.1/sonar-openedge-plugin-2.24.3.jar
+


### PR DESCRIPTION
Link to 2.24.2 was [broken](https://github.com/SonarSource/sonar-update-center-properties/pull/486#issuecomment-1916563000), so you had to remove it. This PR brings the latest version. Sorry for the annoyance !