### PR TITLE
Release ibmix-aem-sonar-rules plugin v1.4

### DIFF
--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -8,13 +8,13 @@ defaults.mavenGroupId=ix.ibm.sonar.java.rules
 defaults.mavenArtifactId=ibmix-aem-sonar-rules
 
 1.4.description=New rules added for AEM testing
-1.4.sqVersions=[9.9,10.4]
+1.4.sqVersions=[9.9,LATEST]
 1.4.date=2024-02-28
 1.4.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.4
 1.4.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.4/ibmix-aem-sonar-rules-1.4.jar
 
 1.3.description=Bugfixes and improvements, compatibility changes
-1.3.sqVersions=[9.9,10.4]
+1.3.sqVersions=[9.9,10.4.*]
 1.3.date=2023-12-13
 1.3.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.3
 1.3.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.3/ibmix-aem-sonar-rules-1.3.jar

--- a/ibmixaemrules.properties
+++ b/ibmixaemrules.properties
@@ -1,11 +1,17 @@
 category=External Analysers
 description=Plugin containing custom Sonar rules for AEM development based on IBM iX internal guidelines
 homepageUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin
-archivedVersions=
-publicVersions=1.3
+archivedVersions=1.3
+publicVersions=1.4
 
 defaults.mavenGroupId=ix.ibm.sonar.java.rules
 defaults.mavenArtifactId=ibmix-aem-sonar-rules
+
+1.4.description=New rules added for AEM testing
+1.4.sqVersions=[9.9,10.4]
+1.4.date=2024-02-28
+1.4.changelogUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/tag/v1.4
+1.4.downloadUrl=https://github.com/IBM/ibm-ix-aem-sonarqube-plugin/releases/download/v1.4/ibmix-aem-sonar-rules-1.4.jar
 
 1.3.description=Bugfixes and improvements, compatibility changes
 1.3.sqVersions=[9.9,10.4]


### PR DESCRIPTION
Version 1.4 release of the ibmix-aem-sonar-rules plugin

SonarCloud dashboard - https://sonarcloud.io/summary/new_code?id=ibmix-aem-sonar-rules