### PR TITLE
Update sonar-dependency-check-plugin to 5.0.0

### DIFF
--- a/dependencycheck.properties
+++ b/dependencycheck.properties
@@ -2,9 +2,15 @@ category=Integration
 description=Integrates Dependency-Check reports into SonarQube
 homepageUrl=https://github.com/dependency-check/dependency-check-sonar-plugin
 archivedVersions=3.0.1,3.1.0,4.0.0
-publicVersions=4.0.1
+publicVersions=4.0.1,5.0.0
 defaults.mavenGroupId=org.sonarsource.owasp
 defaults.mavenArtifactId=sonar-dependency-check-plugin
+
+5.0.0.description=Update SonarQube-API and SonarSource Parent
+5.0.0.sqVersions=[10.4, LATEST]
+5.0.0.date=2024-04-03
+5.0.0.changelogUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/tag/5.0.0
+5.0.0.downloadUrl=https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/5.0.0/sonar-dependency-check-plugin-5.0.0.jar
 
 4.0.1.description=Support dependency-check 9.0.2
 4.0.1.sqVersions=[9.9,10.4]


### PR DESCRIPTION
We've released sonar-dependency-check-plugin version 5.0.0, please add it to the marketplace.
Thanks in advance!

Closes https://github.com/dependency-check/dependency-check-sonar-plugin/issues/911

I want the SonarQube LTS version 9.9.x to continue to receive the old version 4.0.1, is that correct with the two public versions?

SonarCloud-Dashboard: https://sonarcloud.io/dashboard?id=dependency-check_dependency-check-sonar-plugin
