### PR TITLE
Update sonar-l10n-zh-10.5 for Sonarqube-10.5.

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -1,17 +1,29 @@
 category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
-archivedVersions=
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4
+archivedVersions=10.4
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+10.5.description=Support SonarQube 10.5
+10.5.sqVersions=[10.5,LATEST]
+10.5.date=2024-04-13
+10.5.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.5
+10.5.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.5/sonar-l10n-zh-plugin-10.5.jar
+
 10.4.description=Support SonarQube 10.4
-10.4.sqVersions=[10.4,LATEST]
+10.4.sqVersions=[10.4,10.4.1]
 10.4.date=2024-02-10
 10.4.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.4
 10.4.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.4/sonar-l10n-zh-plugin-10.4.jar
+
+10.4.1.description=Support SonarQube 10.4.1
+10.4.1.sqVersions=[10.4,10.4.*]
+10.4.1.date=2024-03-12
+10.4.1.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.4.1
+10.4.1.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.4.1/sonar-l10n-zh-plugin-10.4.1.jar
 
 10.3.description=Support SonarQube 10.3
 10.3.sqVersions=[10.3,10.3.*]


### PR DESCRIPTION
Hi,
sonar-l10n-zh-plugin-10.5 has been released.

The main changes is support SonarQube 10.5.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.5/sonar-l10n-zh-plugin-10.5.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards
