### PR TITLE
fix(BUILD-5327): find cloudfront distribution ID

### DIFF
--- a/po-generate-update-center-prod/upload-sc.sh
+++ b/po-generate-update-center-prod/upload-sc.sh
@@ -29,5 +29,6 @@ echo "Upload done"
 rm -rf "$TRANSFER_DIR"
 trap - EXIT
 
-DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[*].{id:Id,origin:Origins.Items[0].DomainName}[?starts_with(origin,'$S3_BUCKET')].id" --output text)
+DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[*].{id:Id,origin:Origins.Items[].{DomainName:DomainName}[?starts_with(DomainName,'$S3_BUCKET')]}[?not_null(origin)].id" --output text)
+echo "Create CloudFront invalidation for distribution $DISTRIBUTION_ID"
 aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "${paths[@]}"

--- a/po-generate-update-center-prod/upload.sh
+++ b/po-generate-update-center-prod/upload.sh
@@ -11,5 +11,6 @@ aws s3 sync "$@" --delete "$TRANSFER_DIR" "s3://$S3_BUCKET/$S3_PATH/"
 rm -rf "$TRANSFER_DIR"
 echo "Upload done"
 
-DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[*].{id:Id,origin:Origins.Items[0].DomainName}[?starts_with(origin,'$S3_BUCKET')].id" --output text)
+DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[*].{id:Id,origin:Origins.Items[].{DomainName:DomainName}[?starts_with(DomainName,'$S3_BUCKET')]}[?not_null(origin)].id" --output text)
+echo "Create CloudFront invalidation for distribution $DISTRIBUTION_ID"
 aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/$S3_PATH/*" "/$S3_PATH/plugins/*"


### PR DESCRIPTION
Due to infrastructure changes to remove the public access to S3 buckets, the original JMESPATH query is failing on the array index.
This new query is more generic.