### PR TITLE
BUILD-5236 Rename VSTS to AzDO

### DIFF
--- a/scannerazure.properties
+++ b/scannerazure.properties
@@ -4,8 +4,8 @@ license=GNU LGPL 3
 organization=SonarSource
 organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-azure-devops/
-issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/VSTS/issues
-sourcesUrl=https://github.com/SonarSource/sonar-scanner-vsts
+issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SONARAZDO/issues
+sourcesUrl=https://github.com/SonarSource/sonar-scanner-azdo
 archivedVersions=4.7,4.7.1,4.7.2,4.8,4.8.1,4.9,4.10,4.11,4.12,4.16,4.17,4.18,4.19,4.20,4.21,4.22,4.23,4.23.1,5.0.0,5.1.0,5.1.1,5.2.0,5.3.0,5.4.0,5.5.0,5.6.0,5.6.1,5.7.0,5.8.0,5.8.1,5.9.0,5.10.0,5.11.0,5.11.1,5.12.0,5.13.0,5.14.0,5.15.0,5.16.0,5.17.2,5.18.2,5.18.3,5.18.4,5.19.0,5.19.1,5.19.2,5.20.0,6.0.0,6.0.1
 publicVersions=6.1.0
 
@@ -154,7 +154,7 @@ publicVersions=6.1.0
 5.2.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project+%3D+10078+AND+fixVersion+%3D+10877
 5.2.0.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube
 
-5.1.1.description=Revert part of the change for VSTS-264
+5.1.1.description=Revert part of the change for SONARAZDO-264
 5.1.1.date=2021-11-30
 5.1.1.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project+%3D+10078+AND+fixVersion+%3D+10874
 5.1.1.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube

--- a/scannerazuresc.properties
+++ b/scannerazuresc.properties
@@ -4,19 +4,19 @@ license=GNU LGPL 3
 organization=SonarSource
 organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarsource.com/sonarcloud/advanced-setup/ci-based-analysis/sonarcloud-extension-for-azure-devops/
-issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/VSTS/issues
-sourcesUrl=https://github.com/SonarSource/sonar-scanner-vsts
+issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SONARAZDO/issues
+sourcesUrl=https://github.com/SonarSource/sonar-scanner-azdo
 archivedVersions=1.44.0,1.44.1,1.44.2,1.45.0,1.46.0,2.0.0
 publicVersions=2.0.1
 
 2.0.1.description=Deprecate the old SonarCloud v1 tasks with proper warnings
 2.0.1.date=2024-06-10
-2.0.1.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20VSTS%20AND%20fixVersion%20%3D%2015684
+2.0.1.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SONARAZDO%20AND%20fixVersion%20%3D%2015684
 2.0.1.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud
 
 2.0.0.description=New V6 task with configurable scanner version, Drop of V3 tasks, bump of agent requirements for V4 tasks
 2.0.0.date=2024-05-31
-2.0.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20VSTS%20AND%20fixVersion%20%3D%2015677
+2.0.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SONARAZDO%20AND%20fixVersion%20%3D%2015677
 2.0.0.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud
 
 1.46.0.description=Support for JDK 21 and Bump to Scanner for .NET 5.15.1 (fix for .NET 8 on MacOS)
@@ -26,20 +26,20 @@ publicVersions=2.0.1
 
 1.45.0.description=Expose accepted issues, align with CCT design
 1.45.0.date=2024-03-05
-1.45.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20VSTS%20AND%20fixVersion%20%3D%2015466
+1.45.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SONARAZDO%20AND%20fixVersion%20%3D%2015466
 1.45.0.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud
 
 1.44.2.description=Revert request library
 1.44.2.date=2023-10-18
-1.44.2.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20VSTS%20AND%20fixVersion%20%3D%2015354
+1.44.2.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SONARAZDO%20AND%20fixVersion%20%3D%2015354
 1.44.2.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud
 
 1.44.1.description=Fix request headers for proxy configuration
 1.44.1.date=2023-10-18
-1.44.1.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20VSTS%20AND%20fixVersion%20%3D%2015352
+1.44.1.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SONARAZDO%20AND%20fixVersion%20%3D%2015352
 1.44.1.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud
 
 1.44.0.description=Revert change being done to population sonar.branch.name
 1.44.0.date=2023-10-18
-1.44.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20VSTS%20AND%20fixVersion%20%3D%2015346
+1.44.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SONARAZDO%20AND%20fixVersion%20%3D%2015346
 1.44.0.downloadUrl=https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud


### PR DESCRIPTION
The repository was recently renamed to sonar-scanner-azdo, and the Jira project SONARAZDO, this PR reflects this change to this repository

See [ticket](https://sonarsource.atlassian.net/browse/BUILD-5236) for context