### PR TITLE
sonar-l10n-zh-plugin-10.6 support SonarQube-10.6

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=10.4
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+10.6.description=Support SonarQube 10.6
+10.6.sqVersions=[10.6,LATEST]
+10.6.date=2024-06-27
+10.6.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.6
+10.6.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.6/sonar-l10n-zh-plugin-10.6.jar
+
 10.5.description=Support SonarQube 10.5
-10.5.sqVersions=[10.5,LATEST]
+10.5.sqVersions=[10.5,10.5.*]
 10.5.date=2024-04-13
 10.5.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.5
 10.5.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.5/sonar-l10n-zh-plugin-10.5.jar


### PR DESCRIPTION
Hi,
sonar-l10n-zh-plugin-10.6 has been released.

The main changes is support SonarQube 10.6.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.6/sonar-l10n-zh-plugin-10.6.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards