### PR TITLE
ltsVersion to ltaVersion

### DIFF
--- a/update-center-source-sc.properties
+++ b/update-center-source-sc.properties
@@ -1,7 +1,7 @@
 scanners=scannerazuresc
 
 publicVersions=0.0
-ltsVersion=0.0.0
+ltaVersion=0.0.0
 
 0.0.description=Dummy
 0.0.downloadUrl=https://example.com


### PR DESCRIPTION
Change from ltsVersion to ltaVersion because it looks to be mandatory to deliver the Update Center for SC