### PR TITLE
BUILD-5727 Use JDK21 LTS instead of JDK19 EOL

### DIFF
--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -1,5 +1,5 @@
 ARG CIRRUS_AWS_ACCOUNT
-FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j19-m3.9-latest
+FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j21-m3.9-latest
 
 USER root
 


### PR DESCRIPTION
## Changes

- [x] Adapt the base image used by Cirrus CI so that it use JDK21 LTS rather than the EOL JDK19 (the JDK19 images will no longer be produced internally see https://sonarsource.atlassian.net/browse/BUILD-5727)