### PR TITLE
BUILD-6540: Use new AWS profile instead of vault credentials

### DIFF
--- a/po-generate-update-center-prod/.envrc
+++ b/po-generate-update-center-prod/.envrc
@@ -1,13 +1,9 @@
-AWS_DEFAULT_REGION=eu-central-1
-# shellcheck disable=SC2046,SC2183
-vault status >/dev/null 2>&1 || {
-  echo "Please run: vault-login-staging"
-  exit 1
-}
-json=$(vault read -format json development/aws/sts/downloads | jq -r '.data')
-AWS_ACCESS_KEY_ID=$(jq -r '.access_key' <<< "$json")
-AWS_SECRET_ACCESS_KEY=$(jq -r '.secret_key' <<< "$json")
-AWS_SESSION_TOKEN=$(jq -r '.security_token' <<< "$json")
-export AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-export S3_BUCKET=downloads-cdn-eu-central-1-staging
+export AWS_CONFIG_FILE="${PWD}/aws_sso_profiles.conf"
+export AWS_PROFILE="${TARGET:-staging}"
+export S3_BUCKET="downloads-cdn-eu-central-1-$AWS_PROFILE"
 export CIRRUS_BUILD_ID=1234
+
+echo
+echo "Authenticate to AWS with the following commands:"
+echo "$ aws sso login --sso-session sonar"
+echo

--- a/po-generate-update-center-prod/README.md
+++ b/po-generate-update-center-prod/README.md
@@ -7,19 +7,16 @@ This is for local usage.
 ### Requirements
 
 - direnv https://direnv.net/
-- Vault CLI https://www.vaultproject.io/downloads
-- Vault setup
-  [xtranet/RE/HashiCorp+Vault#Generate-TOTP-URIs-(admin)](https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2466316312/HashiCorp+Vault#Generate-TOTP-URIs-(admin))
-- JQ (Stedolan) https://stedolan.github.io/jq/download/
 - Maven Developer
   setup [xtranet/DEV/Developer+Box#Maven-Settings](https://xtranet-sonarsource.atlassian.net/wiki/spaces/DEV/pages/776711/Developer+Box#Maven-Settings)
+- Access to `SonarSource-Staging` AWS account `RECDNElevatedStaging` role
 
 ### Usage
 
 ```shell
 cd po-generate-update-center-prod
-vault-login-staging
 direnv allow
+aws sso login --sso-session sonar
 ```
 
 The environment will now be provisioned to work with Staging account.

--- a/po-generate-update-center-prod/aws_sso_profiles.conf
+++ b/po-generate-update-center-prod/aws_sso_profiles.conf
@@ -1,0 +1,25 @@
+[sso-session sonar]
+sso_start_url = https://sonar.awsapps.com/start#
+sso_region = eu-central-1
+sso_registration_scopes = sso:account:access
+
+[profile dev]
+sso_session = sonar
+sso_account_id = 755792556741
+sso_role_name = RECDNElevatedDevelopment
+region = eu-central-1
+duration_seconds = 14400  # 4h
+
+[profile staging]
+sso_session = sonar
+sso_account_id = 252550591647
+sso_role_name = RECDNElevatedStaging
+region = eu-central-1
+duration_seconds = 14400  # 4h
+
+[profile prod]
+sso_session = sonar
+sso_account_id = 826850611646
+sso_role_name = RECDNElevatedProduction
+region = eu-central-1
+duration_seconds = 14400  # 4h


### PR DESCRIPTION
The vault credentials should not be used for manual deployment. Using the AWS role `RECDNElevatedStaging` instead