### PR TITLE
Update scannermaven.properties

### DIFF
--- a/scannermaven.properties
+++ b/scannermaven.properties
@@ -6,8 +6,13 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-maven/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/MSONAR/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-maven
-archivedVersions=3.6.1,3.7,3.8,3.9,3.9.1,3.10,3.11
-publicVersions=4.0
+archivedVersions=3.6.1,3.7,3.8,3.9,3.9.1,3.10,3.11,4.0
+publicVersions=5.0
+
+5.0.description=Automatic JRE provisioning
+5.0.date=2024-11-06
+5.0.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010140%20AND%20fixversion%20%3D%205.0
+5.0.downloadUrl=https://central.sonatype.com/artifact/org.sonarsource.scanner.maven/sonar-maven-plugin/versions
 
 4.0.description=Drop support of Java 8 runtime
 4.0.date=2024-05-31


### PR DESCRIPTION
I am not sure if we should mention SQ compatibility to be >= 10.6; the scanner wouldn't fail with a lower version, but the provisioning would be disabled.