### PR TITLE
sonar-l10n-zh-24.12

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,15 +2,23 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=10.4
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+24.12.description=Support SonarQube 24.12
+24.12.sqs=[10.8,LATEST]
+24.12.sqcb=[24.12,LATEST]
+24.12.sqVersions=[24.12,LATEST]
+24.12.date=2024-12-06
+24.12.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-24.12
+24.12.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-24.12/sonar-l10n-zh-plugin-24.12.jar
+
 10.7.description=Support SonarQube 10.7
-10.7.sqs=[10.8,LATEST]
-10.7.sqcb=[24.12,LATEST]
-10.7.sqVersions=[10.7,10.7]
+10.7.sqs=[10.7,10.7.*]
+10.7.sqcb=[10.7,10.7.*]
+10.7.sqVersions=[10.7,10.7.*]
 10.7.date=2024-10-01
 10.7.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.7
 10.7.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.7/sonar-l10n-zh-plugin-10.7.jar

--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -10,15 +10,12 @@ defaults.mavenArtifactId=sonar-l10n-zh-plugin
 24.12.description=Support SonarQube 24.12
 24.12.sqs=[10.8,LATEST]
 24.12.sqcb=[24.12,LATEST]
-24.12.sqVersions=[24.12,LATEST]
 24.12.date=2024-12-06
 24.12.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-24.12
 24.12.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-24.12/sonar-l10n-zh-plugin-24.12.jar
 
 10.7.description=Support SonarQube 10.7
-10.7.sqs=[10.7,10.7.*]
-10.7.sqcb=[10.7,10.7.*]
-10.7.sqVersions=[10.7,10.7.*]
+10.7.sqVersions=10.7
 10.7.date=2024-10-01
 10.7.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-10.7
 10.7.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-10.7/sonar-l10n-zh-plugin-10.7.jar


### PR DESCRIPTION


Hi,
sonar-l10n-zh-plugin-10.7 has been released.

The main changes is support SonarQube 24.12.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-24.12/sonar-l10n-zh-plugin-24.12.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards
