### PR TITLE
Release SonarDelphi plugin v1.12.1

### DIFF
--- a/communitydelphi.properties
+++ b/communitydelphi.properties
@@ -1,23 +1,31 @@
 category=Languages
 description=Code Analyzer for Delphi
 homepageUrl=https://github.com/integrated-application-development/sonar-delphi
-archivedVersions=1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0
-publicVersions=1.12.0
+archivedVersions=1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0
+publicVersions=1.12.1
 
 defaults.mavenGroupId=au.com.integradev.delphi
 defaults.mavenArtifactId=sonar-delphi-plugin
 
+1.12.1.description=Improvements to PlatformDependentTruncation, bug fixes
+1.12.1.sqs=[10.8,LATEST]
+1.12.1.sqcb=[24.12,LATEST]
+1.12.1.sqVersions=[9.9,10.7]
+1.12.1.date=2024-12-06
+1.12.1.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.12.1
+1.12.1.downloadUrl=https://github.com/integrated-application-development/sonar-delphi/releases/download/v1.12.1/sonar-delphi-plugin-1.12.1.jar
+
 1.12.0.description=Improvements to intrinsics, parsing improvements, bug fixes
-1.12.0.sqs=[10.8,LATEST]
-1.12.0.sqcb=[24.12,LATEST]
+1.12.0.sqs=[10.8, 10.8.*]
+1.12.0.sqcb=[24.12, 24.12.*]
 1.12.0.sqVersions=[9.9,10.7]
 1.12.0.date=2024-12-02
 1.12.0.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.12.0
 1.12.0.downloadUrl=https://github.com/integrated-application-development/sonar-delphi/releases/download/v1.12.0/sonar-delphi-plugin-1.12.0.jar
 
 1.11.0.description=1 new rule, improvements to procedural type handling, bug fixes
-1.11.0.sqs=[10.8.*]
-1.11.0.sqcb=[24.12.*]
+1.11.0.sqs=[10.8, 10.8.*]
+1.11.0.sqcb=[24.12, 24.12.*]
 1.11.0.sqVersions=[9.9,10.7]
 1.11.0.date=2024-11-04
 1.11.0.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.11.0


### PR DESCRIPTION
SonarDelphi v1.12.1 has been released:

- [Release Notes](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.12.1)
- [SonarCloud](https://sonarcloud.io/project/overview?id=integrated-application-development_sonar-delphi)

Please add it to the marketplace.

Thanks!