### PR TITLE
communitybsl: update 1.15.1

### DIFF
--- a/communitybsl.properties
+++ b/communitybsl.properties
@@ -1,15 +1,23 @@
 category=Languages
 description=Code Analyzer for 1C (BSL)
 homepageUrl=https://1c-syntax.github.io/sonar-bsl-plugin-community/en
-archivedVersions=1.11.0,1.12.0,1.13.0,1.14.0
-publicVersions=1.15.0
+archivedVersions=1.11.0,1.12.0,1.13.0,1.14.0,1.15.0
+publicVersions=1.15.1
 
 defaults.mavenGroupId=com.github.1c-syntax
 defaults.mavenArtifactId=sonar-communitybsl-plugin
 
+1.15.1.description=Bug fixes
+1.15.1.sqs=[10.8,LATEST]
+1.15.1.sqcb=[24.12,LATEST]
+1.15.1.sqVersions=[9.9,10.7]
+1.15.1.date=2024-12-29
+1.15.1.changelogUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/tag/v1.15.1
+1.15.1.downloadUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/download/v1.15.1/sonar-communitybsl-plugin-1.15.1.jar
+
 1.15.0.description=Performance optimization, filtering by subsystems
-1.15.0.sqs=[10.8,LATEST]
-1.15.0.sqcb=[24.12,LATEST]
+1.15.0.sqs=[10.8,10.8.*]
+1.15.0.sqcb=[24.12,24.12]
 1.15.0.sqVersions=[9.9,10.7]
 1.15.0.date=2024-07-12
 1.15.0.changelogUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/tag/v1.15.0


### PR DESCRIPTION
Hello there. communitybsl 1.15.1 is out. 

SonarCloud project: https://sonarcloud.io/project/overview?id=1c-syntax_sonar-bsl-plugin-community 