### PR TITLE
sonar-l10n-zh-25.1

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,14 +2,20 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=10.4
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+25.1.description=Support SonarQube 25.1
+25.1.sqcb=[25.1,LATEST]
+25.1.date=2025-01-08
+25.1.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.1
+25.1.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.1/sonar-l10n-zh-plugin-25.1.jar
+
 24.12.description=Support SonarQube 24.12
 24.12.sqs=[10.8,LATEST]
-24.12.sqcb=[24.12,LATEST]
+24.12.sqcb=[24.12,24.12.*]
 24.12.date=2024-12-06
 24.12.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-24.12
 24.12.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-24.12/sonar-l10n-zh-plugin-24.12.jar


### PR DESCRIPTION
Hi,
sonar-l10n-zh-plugin-25.1 has been released.

The main changes is support SonarQube 25.1.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.1/sonar-l10n-zh-plugin-25.1.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards
