### PR TITLE
REL-3507 Add 2025.1 downloadUrl for <=10.7 compatibility

### DIFF
--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -13,6 +13,9 @@ ltaVersion=2025.1
 pastLtaVersion=9.9.8
 
 2025.1.description=Long-Term Active version - advanced AI capabilities, many security breakthroughs, enhanced developer experience, simplified operability, many new language features, and much more
+# "downloadUrl" needed to notify users of SQ<=10.7 of new releases linking to the general download page since there is
+# no specific Community download link for the LTA version
+2025.1.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube
 2025.1.downloadDeveloperUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-2025.1.0.102418.zip
 2025.1.downloadEnterpriseUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-2025.1.0.102418.zip
 2025.1.downloadDatacenterUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-2025.1.0.102418.zip


### PR DESCRIPTION
Validate locally by reproducing the error without the downloadUrl available when running a 10.7 Community Edition.

By adding the property in the file the modal gets displayed properly without JS errors:

![image](https://github.com/user-attachments/assets/e6907942-2d0e-4045-8250-b666248a43fd)



https://github.com/user-attachments/assets/7466e0ae-9677-44a6-b550-0d6ec4f690c9




