### PR TITLE
Update sonar-l10n-zh-tw version to support SonarQube versions 25.1 and 25.2.

### DIFF
--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,14 +2,20 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1
+publicVersions=1.0,1.1,1.2
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+1.2.description=Support 25.1 25.2
+1.2.sqcb=[25.1,LATEST]
+1.2.date=2025-02-26
+1.2.changelogUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/commits/1.2
+1.2.downloadUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/releases/download/1.2/sonar-l10n-zh-tw-plugin-1.2.jar
+
 1.1.description=SonarQube Traditional Chinese Pack Support SonarQube 10.* Version
 1.1.sqs=[10.8,LATEST]
-1.1.sqcb=[24.12,LATEST]
+1.1.sqcb=[24.12,24.12.*]
 1.1.sqVersions=[10.0,10.7]
 1.1.date=2024-10-21
 1.1.changelogUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/releases/tag/1.1


### PR DESCRIPTION
Hello, I want to release a new version of sonar-l10n-zh-tw to support SonarQube 25.1 and 25.2. Thanks.

(Local screenshot)
![image](https://github.com/user-attachments/assets/57acfd31-c747-49ab-9eac-c9f00d0425e7)
