### PR TITLE
Added Sonar jQAssistant Plugin 3.0.0

### DIFF
--- a/jqassistant.properties
+++ b/jqassistant.properties
@@ -2,10 +2,17 @@ category=External Analyzers
 description=Analyze issues reported by jQAssistant.
 homepageUrl=https://github.com/jqassistant-contrib/sonar-jqassistant-plugin
 archivedVersions=1.12.0,1.12.1
-publicVersions=2.0.0
+publicVersions=2.0.0,3.0.0
 
 defaults.mavenGroupId=org.jqassistant.contrib.sonarqube
 defaults.mavenArtifactId=sonar-jqassistant-plugin
+
+3.0.0.description=Upgraded compatibility to SonarQube 2025 LTA and newer
+3.0.0.date=2025-05-14
+3.0.0.sqs=[10.8,LATEST]
+3.0.0.sqcb=[24.12,LATEST]
+3.0.0.changelogUrl=https://github.com/jqassistant-tooling/sonar-jqassistant-plugin/blob/master/release-notes.adoc#300
+3.0.0.downloadUrl=https://search.maven.org/remotecontent?filepath=org/jqassistant/tooling/sonarqube/sonar-jqassistant-plugin/3.0.0/sonar-jqassistant-plugin-3.0.0.jar
 
 2.0.0.description=Upgraded compatibility to jQAssistant 2.0 and SonarQube 9.9 (LTS)
 2.0.0.date=2023-08-27


### PR DESCRIPTION
The jQAssistant plugin for Sonar 3.0.0 has been in released bringing compatibility with newer SQ versions and we would like to publish it to the marketplace.

