### PR TITLE
sonar-l10n-zh-25.6

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,43 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=10.4
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1,25.2,25.3,25.4,25.5,25.6
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+25.6.description=Support SonarQube 25.6
+25.6.sqcb=[25.6,LATEST]
+25.6.date=2025-06-06
+25.6.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.6
+25.6.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.6/sonar-l10n-zh-plugin-25.6.jar
+
+25.5.description=Support SonarQube 25.5
+25.5.sqcb=[25.5,25.5]
+25.5.date=2025-06-06
+25.5.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.5
+25.5.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.5/sonar-l10n-zh-plugin-25.5.jar
+
+25.4.description=Support SonarQube 25.4
+25.4.sqcb=[25.4,25.4]
+25.4.date=2025-06-06
+25.4.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.4
+25.4.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.4/sonar-l10n-zh-plugin-25.4.jar
+
+25.3.description=Support SonarQube 25.3
+25.3.sqcb=[25.3,25.3]
+25.3.date=2025-06-06
+25.3.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.3
+25.3.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.3/sonar-l10n-zh-plugin-25.3.jar
+
+25.2.description=Support SonarQube 25.2
+25.2.sqcb=[25.2,25.2]
+25.2.date=2025-06-06
+25.2.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.2
+25.2.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.2/sonar-l10n-zh-plugin-25.2.jar
+
 25.1.description=Support SonarQube 25.1
-25.1.sqcb=[25.1,LATEST]
+25.1.sqcb=[25.1,25.1]
 25.1.date=2025-01-24
 25.1.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.1
 25.1.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.1/sonar-l10n-zh-plugin-25.1.jar


### PR DESCRIPTION
Hi,
sonar-l10n-zh-plugin-25.6 has been released.

The main changes is support SonarQube 25.6.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.6/sonar-l10n-zh-plugin-25.6.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

And I added 25.2 to 25.5 for related version.

Please update the market place.

Thank you

Regards
