### PR TITLE
Release SonarDelphi plugin v.1.17.1

### DIFF
--- a/communitydelphi.properties
+++ b/communitydelphi.properties
@@ -1,15 +1,23 @@
 category=Languages
 description=Code Analyzer for Delphi
 homepageUrl=https://github.com/integrated-application-development/sonar-delphi
-archivedVersions=1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.12.1,1.12.2,1.13.0,1.14.0,1.14.1,1.15.0,1.16.0
-publicVersions=1.17.0
+archivedVersions=1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.12.1,1.12.2,1.13.0,1.14.0,1.14.1,1.15.0,1.16.0,1.17.0
+publicVersions=1.17.1
 
 defaults.mavenGroupId=au.com.integradev.delphi
 defaults.mavenArtifactId=sonar-delphi-plugin
 
+1.17.1.description=Improved semantic analysis
+1.17.1.sqs=[10.8,LATEST]
+1.17.1.sqcb=[24.12,LATEST]
+1.17.1.sqVersions=[9.9,10.7]
+1.17.1.date=2025-06-10
+1.17.1.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.17.1
+1.17.1.downloadUrl=https://github.com/integrated-application-development/sonar-delphi/releases/download/v1.17.1/sonar-delphi-plugin-1.17.1.jar
+
 1.17.0.description=Improved semantic analysis, type resolution improvements, bug fixes
-1.17.0.sqs=[10.8,LATEST]
-1.17.0.sqcb=[24.12,LATEST]
+1.17.0.sqs=[10.8,2025.3.*]
+1.17.0.sqcb=[24.12,25.6.*]
 1.17.0.sqVersions=[9.9,10.7]
 1.17.0.date=2025-05-15
 1.17.0.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.17.0


### PR DESCRIPTION
SonarDelphi v1.17.1 has been released:

- [Release Notes](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.17.1)
- [SonarCloud](https://sonarcloud.io/project/overview?id=integrated-application-development_sonar-delphi)

Please add it to the marketplace.

Thanks!