### PR TITLE
Release sonar-l10n-zh-tw 1.4

### DIFF
--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -8,13 +8,13 @@ defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
 1.3.description=Support for 25.3 to 25.6
-1.3.sqcb=[25.3,25.6]
+1.3.sqcb=[25.3,LATEST]
 1.3.date=2025-06-16
 1.3.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.3
 1.3.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.3/sonar-l10n-zh-tw-plugin-1.3.jar
 
 1.2.description=Support 25.1 25.2
-1.2.sqcb=[25.1,25.2]
+1.2.sqcb=[25.1,25.6]
 1.2.date=2025-02-26
 1.2.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.2
 1.2.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.2/sonar-l10n-zh-tw-plugin-1.2.jar

--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -1,25 +1,31 @@
 category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
-homepageUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw
+homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.2
+publicVersions=1.0,1.1,1.2,1.3
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
-1.2.description=Support 25.1 25.2
-1.2.sqcb=[25.1,LATEST]
-1.2.date=2025-02-26
-1.2.changelogUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/commits/1.2
-1.2.downloadUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/releases/download/1.2/sonar-l10n-zh-tw-plugin-1.2.jar
+1.3.description=Support for 25.3 to 25.6
+1.3.sqcb=[25.3,25.6]
+1.3.date=2025-06-16
+1.3.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.3
+1.3.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.3/sonar-l10n-zh-tw-plugin-1.3.jar
 
-# 1.1.description=SonarQube Traditional Chinese Pack Support SonarQube 10.* Version
-# 1.1.sqs=[10.8,LATEST]
-# 1.1.sqcb=[24.12,24.12.*]
-# 1.1.sqVersions=[10.0,10.7]
-# 1.1.date=2024-10-21
-# 1.1.changelogUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/releases/tag/1.1
-# 1.1.downloadUrl=https://github.com/JE-Chen/sonar-l10n-zh-tw/releases/download/1.1/sonar-l10n-zh-tw-plugin-1.1.jar
+1.2.description=Support 25.1 25.2
+1.2.sqcb=[25.1,25.2]
+1.2.date=2025-02-26
+1.2.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.2
+1.2.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.2/sonar-l10n-zh-tw-plugin-1.2.jar
+
+1.1.description=SonarQube Traditional Chinese Pack Support SonarQube 10.* Version
+1.1.sqs=[10.8,10.8.*]
+1.1.sqcb=[24.12,24.12.*]
+1.1.sqVersions=[10.0,10.7]
+1.1.date=2024-10-21
+1.1.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.1
+1.1.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.1/sonar-l10n-zh-tw-plugin-1.1.jar
 
 1.0.description=SonarQube Traditional Chinese Pack
 1.0.sqVersions=[9.9]

--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3
+publicVersions=1.0,1.1,1.2,1.3,1.4
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
-1.3.description=Support for 25.3 to 25.6
-1.3.sqcb=[25.3,LATEST]
+1.4.description=Support SonarQube versions 25.7
+1.4.sqcb=[25.7,LATEST]
+1.4.date=2025-07-12
+1.4.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.4
+1.4.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.4/sonar-l10n-zh-tw-plugin-1.4.jar
+
+1.3.description=Support for versions 25.3 through 25.6.
+1.3.sqcb=[25.3,25.6]
 1.3.date=2025-06-16
 1.3.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.3
 1.3.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.3/sonar-l10n-zh-tw-plugin-1.3.jar


### PR DESCRIPTION
Hi, I’d like to release sonar-l10n-zh-tw version 1.4 to the market.
* SonarCloud: https://sonarcloud.io/project/overview?id=JE-Chen_sonar-l10n-zh-tw
* Release link: https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.4