### PR TITLE
Update l10nzhtw.properties

### DIFF
--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3,1.4
+publicVersions=1.0,1.1,1.2,1.3,1.4,1.5
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+1.5.description=Support SonarQube versions 25.8
+1.5.sqcb=[25.8,LATEST]
+1.5.date=2025-08-13
+1.5.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.5
+1.5.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.5/sonar-l10n-zh-tw-plugin-1.5.jar
+
 1.4.description=Support SonarQube versions 25.7
-1.4.sqcb=[25.7,LATEST]
+1.4.sqcb=[25.7,25.7]
 1.4.date=2025-07-12
 1.4.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.4
 1.4.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.4/sonar-l10n-zh-tw-plugin-1.4.jar


### PR DESCRIPTION
Hi, I’d like to release sonar-l10n-zh-tw version 1.5 to the market.

- SonarCloud: https://sonarcloud.io/summary/new_code?id=JE-Chen_sonar-l10n-zh-tw&pullRequest=4
- Release link: https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.5