### PR TITLE
sonar-l10n-zh-tw 1.6 for SonarQube 25.9

### DIFF
--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3,1.4,1.5
+publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+1.6.description=Support SonarQube versions 25.8
+1.6.sqcb=[25.9,LATEST]
+1.6.date=2025-09-30
+1.6.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.6
+1.6.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.6/sonar-l10n-zh-tw-plugin-1.6.jar
+
 1.5.description=Support SonarQube versions 25.8
-1.5.sqcb=[25.8,LATEST]
+1.5.sqcb=[25.8,25.8]
 1.5.date=2025-08-13
 1.5.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.5
 1.5.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.5/sonar-l10n-zh-tw-plugin-1.5.jar


### PR DESCRIPTION
Hi, I’d like to release sonar-l10n-zh-tw version 1.6 to the market.

* SonarCloud: https://sonarcloud.io/summary/new_code?id=JE-Chen_sonar-l10n-zh-tw&branch=main
* Release link: https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.6