### PR TITLE
sonar-l10n-zh-25.9

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=10.4
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1,25.2,25.3,25.4,25.5,25.6,25.7,25.8,25.9
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1,25.2,25.3,25.4,25.5,25.6,25.7,25.8,25.9,25.10
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+25.10.description=Support SonarQube 25.10
+25.10.sqcb=[25.10,LATEST]
+25.10.date=2025-10-08
+25.10.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.10
+25.10.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.10/sonar-l10n-zh-plugin-25.10.jar
+
 25.9.description=Support SonarQube 25.9
-25.9.sqcb=[25.9,LATEST]
+25.9.sqcb=[25.9,25.9]
 25.9.date=2025-09-04
 25.9.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-25.9
 25.9.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.9/sonar-l10n-zh-plugin-25.9.jar


### PR DESCRIPTION
Hi,
sonar-l10n-zh-plugin-25.10 has been released.

The main changes is support SonarQube 25.10.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-25.19/sonar-l10n-zh-plugin-25.10.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards
