### PR TITLE
Update SonarScanner for NPM to 4.3.4

### DIFF
--- a/scannernpm.properties
+++ b/scannernpm.properties
@@ -6,8 +6,28 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/npm/introduction/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SCANNPM/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-npm
-archivedVersions=2.8.0,2.9.0,2.10.0,2.11.0,2.12.0,2.13.0,2.14.0,2.15.0,2.16.0,2.17.0,3.0.0,3.1.0,3.2.0,3.3.0,3.4.0,3.5.0,3.6.0,3.7.0,3.8.0,3.9.0,4.0.0,4.0.1,4.0.2,4.0.3,4.0.4,4.1.0,4.1.1,4.1.2,4.1.3,4.2.0,4.2.1,4.2.2,4.2.3,4.2.4,4.2.5,4.2.6,4.2.7,4.2.8
-publicVersions=4.3.0
+archivedVersions=2.8.0,2.9.0,2.10.0,2.11.0,2.12.0,2.13.0,2.14.0,2.15.0,2.16.0,2.17.0,3.0.0,3.1.0,3.2.0,3.3.0,3.4.0,3.5.0,3.6.0,3.7.0,3.8.0,3.9.0,4.0.0,4.0.1,4.0.2,4.0.3,4.0.4,4.1.0,4.1.1,4.1.2,4.1.3,4.2.0,4.2.1,4.2.2,4.2.3,4.2.4,4.2.5,4.2.6,4.2.7,4.2.8,4.3.0,4.3.1,4.3.2,4.3.3
+publicVersions=4.3.4
+
+4.3.4.description=Fix release
+4.3.4.date=2026-01-08
+4.3.4.changelogUrl=https://github.com/SonarSource/sonar-scanner-npm/releases/tag/4.3.4
+4.3.4.downloadUrl=https://www.npmjs.com/package/@sonar/scan/v/4.3.4
+
+4.3.3.description=Update dependencies
+4.3.3.date=2026-01-07
+4.3.3.changelogUrl=https://github.com/SonarSource/sonar-scanner-npm/releases/tag/4.3.3
+4.3.3.downloadUrl=https://www.npmjs.com/package/@sonar/scan/v/4.3.3
+
+4.3.2.description=Fix release to not include dev packages
+4.3.2.date=2025-09-25
+4.3.2.changelogUrl=https://github.com/SonarSource/sonar-scanner-npm/releases/tag/4.3.2
+4.3.2.downloadUrl=https://www.npmjs.com/package/@sonar/scan/v/4.3.2
+
+4.3.1.description=Update dependencies
+4.3.1.date=2025-09-24
+4.3.1.changelogUrl=https://github.com/SonarSource/sonar-scanner-npm/releases/tag/4.3.1
+4.3.1.downloadUrl=https://www.npmjs.com/package/@sonar/scan/v/4.3.1
 
 4.3.0.description=Support `sonar.region`
 4.3.0.date=2025-03-24


### PR DESCRIPTION
Update SonarScanner for NPM to the latest version 4.3.4.

## Changes
- Added missing versions: 4.3.1, 4.3.2, 4.3.3, 4.3.4
- Moved 4.3.0, 4.3.1, 4.3.2, 4.3.3 to archivedVersions
- Set 4.3.4 as publicVersions

## Version Details

| Version | Date | Description |
|---------|------|-------------|
| 4.3.4 | 2026-01-08 | Fix release |
| 4.3.3 | 2026-01-07 | Update dependencies |
| 4.3.2 | 2025-09-25 | Fix release to not include dev packages |
| 4.3.1 | 2025-09-24 | Update dependencies |