### PR TITLE
Upgrade JS Creedengo plugin to 3.0.0

### DIFF
--- a/creedengojavascript.properties
+++ b/creedengojavascript.properties
@@ -1,15 +1,30 @@
 category=External Analysers
 description=Provide a list of static code analyzers (for Javascript language) to highlight code structures that may have a negative ecological impact: energy and resources over-consumption, "fatware", shortening terminals' lifespan, etc.
 homepageUrl=https://github.com/green-code-initiative/creedengo-javascript
-publicVersions=2.1.0
-archivedVersions=2.0.0
+publicVersions=2.2.0,3.0.0
+archivedVersions=2.1.0,2.0.0
 
 defaults.mavenGroupId=org.green-code-initiative
 defaults.mavenArtifactId=creedengo-javascript-plugin
 
+3.0.0.description=Breaking changes: SonarQube Community 25.12+ / Server 2025.6+ support only
+3.0.0.sqs=[2025.6,LATEST]
+3.0.0.sqcb=[25.12,LATEST]
+3.0.0.date=2026-02-03
+3.0.0.downloadUrl=https://github.com/green-code-initiative/creedengo-javascript/releases/download/3.0.0/creedengo-javascript-plugin-3.0.0.jar
+3.0.0.changelogUrl=https://github.com/green-code-initiative/creedengo-javascript/releases/tag/3.0.0
+
+2.2.0.description=ESLint v9 and flat config support; Support for SonarQube up to 25.8
+2.2.0.sqs=[10.8,2025.4]
+2.2.0.sqcb=[24.12,25.8]
+2.2.0.sqVersions=[9.9,10.7.*]
+2.2.0.date=2026-01-15
+2.2.0.downloadUrl=https://github.com/green-code-initiative/creedengo-javascript/releases/download/2.2.0/creedengo-javascript-plugin-2.2.0.jar
+2.2.0.changelogUrl=https://github.com/green-code-initiative/creedengo-javascript/releases/tag/2.2.0
+
 2.1.0.description=3 new rules added; Support for SonarQube up to 25.3
-2.1.0.sqs=[10.8,LATEST]
-2.1.0.sqcb=[24.12,LATEST]
+2.1.0.sqs=[10.8,2025.4]
+2.1.0.sqcb=[24.12,25.8]
 2.1.0.sqVersions=[9.9,10.7.*]
 2.1.0.date=2025-03-31
 2.1.0.downloadUrl=https://github.com/green-code-initiative/creedengo-javascript/releases/download/2.1.0/creedengo-javascript-plugin-2.1.0.jar


### PR DESCRIPTION
Hello 👋 
We have released new versions of creedengo-javascript plugin!

Both versions are public and do not target the same versions of SonarQube.
I have checked that my changes are compliant with the README file 🤞 

🔗 [Official 3.0.0 release announcement](https://github.com/green-code-initiative/creedengo-javascript/releases/tag/3.0.0)
🔗 [Official 2.2.0 release announcement](https://github.com/green-code-initiative/creedengo-javascript/releases/tag/2.2.0)
🏗️ [SonarCloud project page](https://sonarcloud.io/project/overview?id=green-code-initiative_ecoCode-linter)

Thank you,
Regards