### PR TITLE
Add a3openapi plugin

### DIFF
--- a/a3openapi.properties
+++ b/a3openapi.properties
@@ -1,0 +1,15 @@
+category=External Analyzers
+description=Custom SonarQube rules to analyze and improve the quality, security, and consistency of OpenAPI.
+homepageUrl=https://github.com/apiaddicts/sonaropenapi-rules
+archivedVersions=
+publicVersions=1.3.2
+
+defaults.mavenGroupId=org.apiaddicts.apitools.dosonarapi
+defaults.mavenArtifactId=sonaropenapi-rules-community
+
+1.3.2.description=Analyze OpenAPI specifications v1.3.2
+1.3.2.sqs=[10.8,LATEST]
+1.3.2.sqcb=[24.12,LATEST]
+1.3.2.date=2026-03-10
+1.3.2.changelogUrl=https://github.com/apiaddicts/sonaropenapi-rules/releases/tag/1.3.2
+1.3.2.downloadUrl=https://repo1.maven.org/maven2/org/apiaddicts/apitools/dosonarapi/sonaropenapi-rules-community/1.3.2/sonaropenapi-rules-community-1.3.2.jar

--- a/a3openapi.properties
+++ b/a3openapi.properties
@@ -2,14 +2,14 @@ category=External Analyzers
 description=Custom SonarQube rules to analyze and improve the quality, security, and consistency of OpenAPI.
 homepageUrl=https://github.com/apiaddicts/sonaropenapi-rules
 archivedVersions=
-publicVersions=1.3.2
+publicVersions=1.3.5
 
 defaults.mavenGroupId=org.apiaddicts.apitools.dosonarapi
 defaults.mavenArtifactId=sonaropenapi-rules-community
 
-1.3.2.description=Analyze OpenAPI specifications v1.3.2
-1.3.2.sqs=[10.8,LATEST]
-1.3.2.sqcb=[24.12,LATEST]
-1.3.2.date=2026-03-10
-1.3.2.changelogUrl=https://github.com/apiaddicts/sonaropenapi-rules/releases/tag/1.3.2
-1.3.2.downloadUrl=https://repo1.maven.org/maven2/org/apiaddicts/apitools/dosonarapi/sonaropenapi-rules-community/1.3.2/sonaropenapi-rules-community-1.3.2.jar
+1.3.5.description=Community rule set for OpenAPI definitions.
+1.3.5.sqs=[10.8,LATEST]
+1.3.5.sqcb=[24.12,LATEST]
+1.3.5.date=2026-04-08
+1.3.5.changelogUrl=https://github.com/apiaddicts/sonaropenapi-rules/releases/tag/1.3.5
+1.3.5.downloadUrl=https://repo1.maven.org/maven2/org/apiaddicts/apitools/dosonarapi/sonaropenapi-rules-community/1.3.5/sonaropenapi-rules-community-1.3.5.jar

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
+plugins=a3openapi,authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 


### PR DESCRIPTION
Hello!

This is the first release submit for this a3openapi plugin.

- Plugin key: a3openapi
- License: LGPL v3
- Version: 1.3.5
- Project URL: [a3openapi - Github](https://github.com/apiaddicts/sonaropenapi-rules)
- Plugin binaries URL: [a3openapi - v1.3.5](https://repo1.maven.org/maven2/org/apiaddicts/apitools/dosonarapi/sonaropenapi-rules-community/1.3.5/sonaropenapi-rules-community-1.3.5.jar)
- SonarCloud URL: [a3openapi - SonarCloud](https://sonarcloud.io/project/overview?id=apiaddicts_sonaropenapi-rules)
- Issue Tracker: [a3openapi - Github Issues](https://github.com/apiaddicts/sonaropenapi-rules/issues)
- Sonar Community discussion: [[NEW PLUGIN] a3openapi - Requesting inclusion in SonarQube Marketplace](https://community.sonarsource.com/t/new-plugin-a3openapi-requesting-inclusion-in-sonarqube-marketplace/179369)

Please feel free to ask questions about this first integration.

Thank you

Regards