### PR TITLE
Add a3openapicore plugin

### DIFF
--- a/a3openapicore.properties
+++ b/a3openapicore.properties
@@ -1,0 +1,15 @@
+category=Languages
+description=OpenAPI language support for SonarQube. Enables SonarQube to analyze OpenAPI specifications. Serves as the foundation for OpenAPI analysis on SonarQube.
+homepageUrl=https://github.com/apiaddicts/sonar-openapi
+archivedVersions=
+publicVersions=1.1.1
+
+defaults.mavenGroupId=org.apiaddicts.apitools.dosonarapi
+defaults.mavenArtifactId=sonar-openapi-plugin
+
+1.1.1.description=Provides OpenAPI support, including file scanning, parsing, and analysis of YAML and JSON specifications.
+1.1.1.sqs=[10.8,LATEST]
+1.1.1.sqcb=[24.12,LATEST]
+1.1.1.date=2024-09-05
+1.1.1.changelogUrl=https://github.com/apiaddicts/sonar-openapi/releases/tag/v1.1.1
+1.1.1.downloadUrl=https://repo1.maven.org/maven2/org/apiaddicts/apitools/dosonarapi/sonar-openapi-plugin/1.1.1/sonar-openapi-plugin-1.1.1.jar

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
+plugins=a3openapicore,authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 


### PR DESCRIPTION
Hello!

This is the first release submit for this a3openapi plugin.

- Plugin key: a3openapicore
- License: LGPL v3
- Version: 1.1.1
- Project URL: [a3openapicore - Github](https://github.com/apiaddicts/sonar-openapi)
- Plugin binaries URL: [a3openapicore - v1.1.1](https://repo1.maven.org/maven2/org/apiaddicts/apitools/dosonarapi/sonar-openapi-plugin/1.1.1/sonar-openapi-plugin-1.1.1.jar)
- SonarCloud URL: [a3openapicore - SonarCloud](https://sonarcloud.io/project/overview?id=apiaddicts_sonar_openapi)
- Issue Tracker: [a3openapicore - Github Issues](https://github.com/apiaddicts/sonar-openapi/issues)
- Sonar Community Topic: https://community.sonarsource.com/t/requesting-inclusion-in-marketplace-a3openapicore/181023

Please feel free to ask questions about this first integration.

Thank you

Regards