### PR TITLE
Add Korean language pack (l10nko)

### DIFF
--- a/l10nko.properties
+++ b/l10nko.properties
@@ -5,14 +5,14 @@ issueTrackerUrl=https://github.com/leeyudok/sonar-l10n-ko/issues
 license=GNU LGPL 3
 organizationName=leeyudok
 organizationUrl=https://github.com/leeyudok
-publicVersions=2.0.0
+publicVersions=25.8
 
 defaults.mavenGroupId=org.codehaus.l10n.ko
 defaults.mavenArtifactId=sonar-l10n-ko-plugin
 
-2.0.0.description=Support SonarQube 25.x - 100% Korean translation (5,060 keys)
-2.0.0.sqs=[2025.8,LATEST]
-2.0.0.sqcb=[25.8,LATEST]
-2.0.0.date=2026-04-12
-2.0.0.changelogUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/tag/v2.0.0
-2.0.0.downloadUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/download/v2.0.0/sonar-l10n-ko-plugin-2.0.0.jar
+25.8.description=Support SonarQube 25.x - 100% Korean translation (5,060 keys)
+25.8.sqs=[2025.8,LATEST]
+25.8.sqcb=[25.8,LATEST]
+25.8.date=2026-04-12
+25.8.changelogUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/tag/sonar-l10n-ko-plugin-25.8
+25.8.downloadUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/download/sonar-l10n-ko-plugin-25.8/sonar-l10n-ko-plugin-25.8.jar

--- a/l10nko.properties
+++ b/l10nko.properties
@@ -1,0 +1,17 @@
+category=Localization
+description=SonarQube Korean Pack
+homepageUrl=https://github.com/leeyudok/sonar-l10n-ko
+issueTrackerUrl=https://github.com/leeyudok/sonar-l10n-ko/issues
+license=GNU LGPL 3
+organizationName=leeyudok
+organizationUrl=https://github.com/leeyudok
+publicVersions=2.0.0
+
+defaults.mavenGroupId=org.codehaus.l10n.ko
+defaults.mavenArtifactId=sonar-l10n-ko-plugin
+
+2.0.0.description=Support SonarQube 25.x - 100% Korean translation (5,060 keys)
+2.0.0.sqcb=[25.8,LATEST]
+2.0.0.date=2026-04-12
+2.0.0.changelogUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/tag/v2.0.0
+2.0.0.downloadUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/download/v2.0.0/sonar-l10n-ko-plugin-2.0.0.jar

--- a/l10nko.properties
+++ b/l10nko.properties
@@ -11,7 +11,6 @@ defaults.mavenGroupId=org.codehaus.l10n.ko
 defaults.mavenArtifactId=sonar-l10n-ko-plugin
 
 25.8.description=Support SonarQube 25.x - 100% Korean translation (5,060 keys)
-25.8.sqs=[2025.8,LATEST]
 25.8.sqcb=[25.8,LATEST]
 25.8.date=2026-04-12
 25.8.changelogUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/tag/sonar-l10n-ko-plugin-25.8

--- a/l10nko.properties
+++ b/l10nko.properties
@@ -11,6 +11,7 @@ defaults.mavenGroupId=org.codehaus.l10n.ko
 defaults.mavenArtifactId=sonar-l10n-ko-plugin
 
 2.0.0.description=Support SonarQube 25.x - 100% Korean translation (5,060 keys)
+2.0.0.sqs=[2025.8,LATEST]
 2.0.0.sqcb=[25.8,LATEST]
 2.0.0.date=2026-04-12
 2.0.0.changelogUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/tag/v2.0.0

--- a/l10nko.properties
+++ b/l10nko.properties
@@ -12,6 +12,6 @@ defaults.mavenArtifactId=sonar-l10n-ko-plugin
 
 25.8.description=Support SonarQube 25.x - 100% Korean translation (5,060 keys)
 25.8.sqcb=[25.8,LATEST]
-25.8.date=2026-04-12
+25.8.date=2026-04-11
 25.8.changelogUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/tag/sonar-l10n-ko-plugin-25.8
 25.8.downloadUrl=https://github.com/leeyudok/sonar-l10n-ko/releases/download/sonar-l10n-ko-plugin-25.8/sonar-l10n-ko-plugin-25.8.jar

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
+plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nko,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nko,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
+plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nes,l10nfr,l10nja,l10nko,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 


### PR DESCRIPTION
## Summary
- Add Korean language pack plugin (`l10nko`) to the SonarQube marketplace
- Plugin key: `l10nko`
- Category: Localization
- License: GNU LGPL v3

## Plugin details
- **Version**: 2.0.0
- **Compatibility**: SonarQube 25.8+
- **Translation coverage**: 100% (5,060 / 5,060 keys)
- **Homepage**: https://github.com/leeyudok/sonar-l10n-ko
- **Download**: https://github.com/leeyudok/sonar-l10n-ko/releases/download/v2.0.0/sonar-l10n-ko-plugin-2.0.0.jar

## Changes
- `l10nko.properties` — new plugin metadata
- `update-center-source.properties` — added `l10nko` to plugins list

## Context
Korean is one of the few major languages missing from the SonarQube marketplace. This plugin was ported from the original [SonarQubeCommunity/sonar-l10n-ko](https://github.com/SonarQubeCommunity/sonar-l10n-ko) (inactive since 2018) and fully updated for SonarQube 25.x.