### PR TITLE
Update l10n-zh-tw to version 26.4

### DIFF
--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+1.9.description=Support SonarQube versions 26.1
+1.9.sqcb=[26.1,LATEST]
+1.9.date=2026-02-04
+1.9.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.9
+1.9.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.9/sonar-l10n-zh-tw-plugin-1.9.jar
+
 1.8.description=Support SonarQube versions 25.11 through 25.12
-1.8.sqcb=[25.11,LATEST]
+1.8.sqcb=[25.11,25.12]
 1.8.date=2025-12-27
 1.8.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.8
 1.8.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.8/sonar-l10n-zh-tw-plugin-1.8.jar

--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -7,7 +7,7 @@ publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,26.2
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
-26.2.description=Support SonarQube versions 26.1
+26.2.description=Support SonarQube versions 26.2
 26.2.sqcb=[26.2,LATEST]
 26.2.date=2026-02-28
 26.2.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.2

--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9
+publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,26.2
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+26.2.description=Support SonarQube versions 26.1
+26.2.sqcb=[26.2,LATEST]
+26.2.date=2026-02-28
+26.2.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.2
+26.2.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/26.2/sonar-l10n-zh-tw-plugin-26.2.jar
+
 1.9.description=Support SonarQube versions 26.1
-1.9.sqcb=[26.1,LATEST]
+1.9.sqcb=[26.1,26.1]
 1.9.date=2026-02-04
 1.9.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/1.9
 1.9.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/1.9/sonar-l10n-zh-tw-plugin-1.9.jar

--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,12 +2,18 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,26.2,26.3
+publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,26.2,26.3,26.4
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+26.4.description=Support SonarQube versions 26.4
+26.4.sqcb=[26.4,LATEST]
+26.4.date=2026-04-26
+26.4.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.4
+26.4.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/26.4/sonar-l10n-zh-tw-plugin-26.4.jar
+
 26.3.description=Support SonarQube versions 26.3
-26.3.sqcb=[26.3,LATEST]
+26.3.sqcb=[26.3,26.3]
 26.3.date=2026-03-14
 26.3.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.3
 26.3.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/26.3/sonar-l10n-zh-tw-plugin-26.3.jar

--- a/l10nzhtw.properties
+++ b/l10nzhtw.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Traditional Chinese Language Pack (not compatible with the "Chinese Pack" which uses Simplified Chinese)
 homepageUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw
 archivedVersions=
-publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,26.2
+publicVersions=1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,26.2,26.3
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-tw-plugin
 
+26.3.description=Support SonarQube versions 26.3
+26.3.sqcb=[26.3,LATEST]
+26.3.date=2026-03-14
+26.3.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.3
+26.3.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/26.3/sonar-l10n-zh-tw-plugin-26.3.jar
+
 26.2.description=Support SonarQube versions 26.2
-26.2.sqcb=[26.2,LATEST]
+26.2.sqcb=[26.2,26.2]
 26.2.date=2026-02-28
 26.2.changelogUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.2
 26.2.downloadUrl=https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/download/26.2/sonar-l10n-zh-tw-plugin-26.2.jar


### PR DESCRIPTION
Hi, I’d like to release sonar-l10n-zh-tw version 26.4 to the market.

SonarCloud: https://sonarcloud.io/summary/new_code?id=JE-Chen_sonar-l10n-zh-tw&branch=main
Release Link: https://github.com/SDPM-lab/sonar-l10n-zh-tw/releases/tag/26.4