### PR TITLE
CommunityBSL 1.18.1

### DIFF
--- a/communitybsl.properties
+++ b/communitybsl.properties
@@ -1,15 +1,22 @@
 category=Languages
 description=Code Analyzer for 1C (BSL)
 homepageUrl=https://1c-syntax.github.io/sonar-bsl-plugin-community/en
-archivedVersions=1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.15.1,1.15.2,1.16.1,1.17.0,1.17.2
-publicVersions=1.18.0
+archivedVersions=1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.15.1,1.15.2,1.16.1,1.17.0,1.17.2,1.18.0
+publicVersions=1.18.1
 
 defaults.mavenGroupId=com.github.1c-syntax
 defaults.mavenArtifactId=sonar-communitybsl-plugin
 
+1.18.1.description=Bug fix: scanner crash on multiline SDBL tokens
+1.18.1.sqs=[2025.4,LATEST]
+1.18.1.sqcb=[25.4,LATEST]
+1.18.1.date=2026-04-30
+1.18.1.changelogUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/tag/v1.18.1
+1.18.1.downloadUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/download/v1.18.1/sonar-communitybsl-plugin-1.18.1.jar
+
 1.18.0.description=JDK 21, min. SonarQube 25.4
-1.18.0.sqs=[2025.4,LATEST]
-1.18.0.sqcb=[25.4,LATEST]
+1.18.0.sqs=[2025.4,2026.2.*]
+1.18.0.sqcb=[25.4,26.4.*]
 1.18.0.date=2026-03-26
 1.18.0.changelogUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/tag/v1.18.0
 1.18.0.downloadUrl=https://github.com/1c-syntax/sonar-bsl-plugin-community/releases/download/v1.18.0/sonar-communitybsl-plugin-1.18.0.jar


### PR DESCRIPTION
Hello! 😃
CommunityBSL 1.18.1 is out.

Bug fix: scanner crash on multiline SDBL tokens (e.g. GROUP BY / СГРУППИРОВАТЬ ПО on separate lines in BSL string continuation).

SonarCloud project: https://sonarcloud.io/project/overview?id=1c-syntax_sonar-bsl-plugin-community