### PR TITLE
Update pysonar public version to 1.6

### DIFF
--- a/scannerpython.properties
+++ b/scannerpython.properties
@@ -6,8 +6,13 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner-for-python/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SCANPY/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-python
-archivedVersions=0.1.0.285,0.1.0.340,0.2.0.520,0.3.0.2016,1.0.0.1453,1.0.1.1548,1.0.2.1722,1.1.0.2035,1.2.1.3951,1.3.0.4086
-publicVersions=1.4.0.4676
+archivedVersions=0.1.0.285,0.1.0.340,0.2.0.520,0.3.0.2016,1.0.0.1453,1.0.1.1548,1.0.2.1722,1.1.0.2035,1.2.1.3951,1.3.0.4086,1.4.0.4676
+publicVersions=1.5.0.4793
+
+1.5.0.4793.description=Fix strict dependencies pinning of pysonar
+1.5.0.4793.date=2026-04-30
+1.5.0.4793.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%20%22Sonar%20Scanner%20Python%22%20AND%20fixversion%20%3D%201.5.0
+1.5.0.4793.downloadUrl=https://pypi.org/project/pysonar/1.5.0.4793/
 
 1.4.0.4676.description=Added dry-run mode. Additional improvements, mostly regarding CI.
 1.4.0.4676.date=2026-03-24

--- a/scannerpython.properties
+++ b/scannerpython.properties
@@ -6,8 +6,13 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner-for-python/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SCANPY/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-python
-archivedVersions=0.1.0.285,0.1.0.340,0.2.0.520,0.3.0.2016,1.0.0.1453,1.0.1.1548,1.0.2.1722,1.1.0.2035,1.2.1.3951,1.3.0.4086,1.4.0.4676
-publicVersions=1.5.0.4793
+archivedVersions=0.1.0.285,0.1.0.340,0.2.0.520,0.3.0.2016,1.0.0.1453,1.0.1.1548,1.0.2.1722,1.1.0.2035,1.2.1.3951,1.3.0.4086,1.4.0.4676,1.5.0.4793
+publicVersions=1.6.0.4905
+
+1.6.0.4905.description=Automatic detection of sonar.tests property
+1.6.0.4905.date=2026-05-28
+1.6.0.4905.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%20%22Sonar%20Scanner%20Python%22%20AND%20fixversion%20%3D%201.6.0
+1.6.0.4905.downloadUrl=https://pypi.org/project/pysonar/1.6.0.4905/
 
 1.5.0.4793.description=Fix strict dependencies pinning of pysonar
 1.5.0.4793.date=2026-04-30


### PR DESCRIPTION
----
## Summary by Gitar

- **Version updates:**
  - Added `1.6.0.4905` as the latest public version in `scannerpython.properties`.
  - Included `1.5.0.4793` in the `archivedVersions` and defined its metadata properties.

<sub>This will update automatically on new commits.</sub>