### PR TITLE
Add SBOM Visualization plugin

### DIFF
--- a/cdxsunshine.properties
+++ b/cdxsunshine.properties
@@ -7,9 +7,9 @@ publicVersions=0.1.9
 defaults.mavenGroupId=io.github.mathiasconradt
 defaults.mavenArtifactId=sonarqube-cdx-sunshine-plugin
 
-0.1.6.description=Initial marketplace-ready release with per-project CycloneDX SBOM visualization, SCA risk enrichment, dependency sunburst, and searchable components and vulnerabilities tables
-0.1.6.sqs=[2026.1,LATEST]
-0.1.6.sqcb=
-0.1.6.date=2026-05-09
-0.1.6.changelogUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/tag/v0.1.9
-0.1.6.downloadUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/download/v0.1.9/sonarqube-cdx-sunshine-plugin-0.1.9.jar
+0.1.9.description=Initial marketplace-ready release with per-project CycloneDX SBOM visualization, SCA risk enrichment, dependency sunburst, and searchable components and vulnerabilities tables
+0.1.9.sqs=[2026.1,LATEST]
+0.1.9.sqcb=
+0.1.9.date=2026-05-09
+0.1.9.changelogUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/tag/v0.1.9
+0.1.9.downloadUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/download/v0.1.9/sonarqube-cdx-sunshine-plugin-0.1.9.jar

--- a/cdxsunshine.properties
+++ b/cdxsunshine.properties
@@ -2,7 +2,7 @@ category=Visualization/Reporting
 description=CycloneDX Sunshine SBOM Visualization for SonarQube projects
 homepageUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin
 archivedVersions=
-publicVersions=0.1.6
+publicVersions=0.1.9
 
 defaults.mavenGroupId=io.github.mathiasconradt
 defaults.mavenArtifactId=sonarqube-cdx-sunshine-plugin
@@ -11,5 +11,5 @@ defaults.mavenArtifactId=sonarqube-cdx-sunshine-plugin
 0.1.6.sqs=[2026.1,LATEST]
 0.1.6.sqcb=
 0.1.6.date=2026-05-09
-0.1.6.changelogUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/tag/v0.1.6
-0.1.6.downloadUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/download/v0.1.6/sonarqube-cdx-sunshine-plugin-0.1.6.jar
+0.1.6.changelogUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/tag/v0.1.9
+0.1.6.downloadUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/download/v0.1.9/sonarqube-cdx-sunshine-plugin-0.1.9.jar

--- a/sbomviz.properties
+++ b/sbomviz.properties
@@ -1,0 +1,15 @@
+category=Visualization/Reporting
+description=CycloneDX Sunshine SBOM Visualization for SonarQube projects
+homepageUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin
+archivedVersions=
+publicVersions=0.1.6
+
+defaults.mavenGroupId=io.github.mathiasconradt
+defaults.mavenArtifactId=sonarqube-cdx-sunshine-plugin
+
+0.1.6.description=Initial marketplace-ready release with per-project CycloneDX SBOM visualization, SCA risk enrichment, dependency sunburst, and searchable components and vulnerabilities tables
+0.1.6.sqs=[2026.1,LATEST]
+0.1.6.sqcb=
+0.1.6.date=2026-05-09
+0.1.6.changelogUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/tag/v0.1.6
+0.1.6.downloadUrl=https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/download/v0.1.6/sonarqube-cdx-sunshine-plugin-0.1.6.jar

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml,sbomviz
+plugins=authoidc,cdxsunshine,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,cdxsunshine,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
+plugins=authoidc,cdxsunshine,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nes,l10nfr,l10nja,l10nko,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -1,4 +1,4 @@
-plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml
+plugins=authoidc,checkstyle,communitybsl,communitydelphi,communityrust,creedengocsharp,creedengojava,creedengojavascript,creedengophp,creedengopython,dependencycheck,ecocodeandroid,ecocodecsharp,ecocodejava,ecocodejavascript,ecocodephp,ecocodepython,errorawaysonar,findbugs,hadolint,ibmixaemrules,jqassistant,l10nfr,l10nja,l10nes,l10nru,l10nzh,l10nzhtw,magento2php,mutationanalysis,mybatis,openedge,pmd,shellcheck,rci,scmcvs,scmjazzrtc,scmtfvc,scmmercurial,softvis3d,wolfralyze,yaml,sbomviz
 scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scannerazure,scannerjenkins,scannerpython,scannernpm
 
 


### PR DESCRIPTION
Add the SBOM Visualization community plugin to the Marketplace metadata.

Plugin homepage: https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin
Release: https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/tag/v0.1.6
Download: https://github.com/mathiasconradt/sonarqube-cdx-sunshine-plugin/releases/download/v0.1.6/sonarqube-cdx-sunshine-plugin-0.1.6.jar
SonarCloud project: https://sonarcloud.io/summary/overall?id=mathiasconradt_sonarqube-sbom-visualization-plugin

Validation run locally:

```
mvn org.sonarsource.update-center:sonar-update-center-mojo:1.35.0.2835:generate-metadata -DinputFile=update-center-source.properties -DvalidateOnly=true -DoutputDir=/tmp
```