### PR TITLE
SonarQube Server 2025.1.8 and 2025.4.7

### DIFF
--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -134,6 +134,14 @@ pastLtaVersion=2025.1.7
 25.8.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010139%20AND%20issuetype!%3DMaintenance%20AND%20fixversion%20%3D%2019334
 25.8.date=2025-08-06
 
+2025.4.7.description=Long-Term Active version - LTA bug fixes
+2025.4.7.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube
+2025.4.7.downloadDeveloperUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-2025.4.7.123368.zip
+2025.4.7.downloadEnterpriseUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-2025.4.7.123368.zip
+2025.4.7.downloadDatacenterUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-2025.4.7.123368.zip
+2025.4.7.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%2010139%20AND%20issuetype%20%21%3D%20Maintenance%20AND%20fixversion%20%3D%2033200
+2025.4.7.date=2026-05-27
+
 2025.4.6.description=Long-Term Active version - LTA bug fixes
 2025.4.6.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube
 2025.4.6.downloadDeveloperUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-2025.4.6.121412.zip
@@ -239,6 +247,14 @@ pastLtaVersion=2025.1.7
 25.2.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-25.2.0.102705.zip
 25.2.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010139%20AND%20fixVersion%20%3D%2016130%20AND%20issuetype!%3DMaintenance
 25.2.date=2025-02-03
+
+2025.1.8.description=Long-Term Active version - LTA bug fixes
+2025.1.8.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube
+2025.1.8.downloadDeveloperUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-2025.1.8.123366.zip
+2025.1.8.downloadEnterpriseUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-2025.1.8.123366.zip
+2025.1.8.downloadDatacenterUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-2025.1.8.123366.zip
+2025.1.8.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%2010139%20AND%20issuetype%20!%3D%20Maintenance%20AND%20fixversion%20%3D%2033201	
+2025.1.8.date=2026-05-27
 
 2025.1.7.description=Long-Term Active version - LTA bug fixes
 2025.1.7.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -5,12 +5,12 @@ scanners=scannercli,scannermsbuild,scannerant,scannermaven,scannergradle,scanner
 devVersion=2026.4-SNAPSHOT
 publicVersions=9.9,9.9.1,9.9.2,9.9.3,9.9.4,9.9.5,9.9.6,9.9.7,9.9.8,9.9.9,10.0,10.1,10.2,10.2.1,10.3,10.4,10.4.1,10.5,10.5.1,10.6,10.7
 privateVersions=4.2,4.3,4.3.1,4.3.2,4.3.3,4.4,4.4.1,4.5,4.5.1,4.5.2,4.5.4,4.5.5,4.5.6,4.5.7,5.0,5.0.1,5.1,5.1.1,5.1.2,5.2,5.3,5.4,5.5,5.6,5.6.1,5.6.2,5.6.3,5.6.4,5.6.5,5.6.6,5.6.7,6.0,6.1,6.2,6.3,6.3.1,6.4,6.5,6.6,6.7,6.7.1,6.7.2,6.7.3,6.7.4,6.7.5,6.7.6,6.7.7,7.0,7.1,7.2,7.2.1,7.3,7.4,7.5,7.6,7.7,7.8,7.9,7.9.1,7.9.2,7.9.3,7.9.4,7.9.5,7.9.6,8.0,8.1,8.2,8.3,8.3.1,8.4,8.4.1,8.4.2,8.5,8.5.1,8.6,8.6.1,8.7,8.7.1,8.8,8.9,8.9.1,8.9.2,8.9.3,8.9.4,8.9.5,8.9.6,8.9.7,8.9.8,8.9.9,8.9.10,9.0,9.0.1,9.1,9.2,9.2.1,9.2.2,9.2.3,9.2.4,9.3,9.4,9.5,9.6,9.6.1,9.7,9.7.1,9.8,
-sqs=10.8,10.8.1,2025.1,2025.1.1,2025.1.2,2025.1.3,2025.1.4,2025.1.5,2025.1.6,2025.1.7,2025.2,2025.3,2025.3.1,2025.4.1,2025.4.2,2025.4.3,2025.4.4,2025.4.5,2025.4.6,2025.5,2025.6,2025.6.1,2026.1,2026.1.1,2026.1.2,2026.1.3,2026.2.1,2026.3
+sqs=10.8,10.8.1,2025.1,2025.1.1,2025.1.2,2025.1.3,2025.1.4,2025.1.5,2025.1.6,2025.1.7,2025.1.8,2025.2,2025.3,2025.3.1,2025.4.1,2025.4.2,2025.4.3,2025.4.4,2025.4.5,2025.4.6,2025.4.7,2025.5,2025.6,2025.6.1,2026.1,2026.1.1,2026.1.2,2026.1.3,2026.2.1,2026.3
 sqcb=24.12,25.1,25.2,25.3,25.4,25.5,25.6,25.7,25.8,25.9,25.10,25.11,25.12,26.1,26.2,26.3,26.4,26.5
 
 ltsVersion=2026.1.3
 ltaVersion=2026.1.3
-pastLtaVersion=2025.1.7
+pastLtaVersion=2025.1.8
 
 2026.3.description=Embedded MCP server for AI coding agents, Sonar agentic AI quality profiles, PowerShell support, monitoring performance alerts, GitLab provisioning improvements, VEX export for Advanced Security reporting, 37 new Groovy and Jenkins pipeline rules, and many new Python rules for collections, OOP, and data structures
 2026.3.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube
@@ -253,7 +253,7 @@ pastLtaVersion=2025.1.7
 2025.1.8.downloadDeveloperUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-2025.1.8.123366.zip
 2025.1.8.downloadEnterpriseUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-2025.1.8.123366.zip
 2025.1.8.downloadDatacenterUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-2025.1.8.123366.zip
-2025.1.8.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%2010139%20AND%20issuetype%20!%3D%20Maintenance%20AND%20fixversion%20%3D%2033201	
+2025.1.8.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%2010139%20AND%20issuetype%20!%3D%20Maintenance%20AND%20fixversion%20%3D%2033201
 2025.1.8.date=2026-05-27
 
 2025.1.7.description=Long-Term Active version - LTA bug fixes


### PR DESCRIPTION
----
## Summary by Gitar

- **Version updates:**
  - Added release properties for SonarQube Server `2025.4.7` and `2025.1.8` in `update-center-source.properties`.
  - Included download URLs, changelog links, and release dates for both new versions.


<sub>This will update automatically on new commits.</sub>