### PR TITLE
Update pysonar to 1.7.0

### DIFF
--- a/scannerpython.properties
+++ b/scannerpython.properties
@@ -6,8 +6,13 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner-for-python/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SCANPY/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-python
-archivedVersions=0.1.0.285,0.1.0.340,0.2.0.520,0.3.0.2016,1.0.0.1453,1.0.1.1548,1.0.2.1722,1.1.0.2035,1.2.1.3951,1.3.0.4086,1.4.0.4676,1.5.0.4793
-publicVersions=1.6.0.4905
+archivedVersions=0.1.0.285,0.1.0.340,0.2.0.520,0.3.0.2016,1.0.0.1453,1.0.1.1548,1.0.2.1722,1.1.0.2035,1.2.1.3951,1.3.0.4086,1.4.0.4676,1.5.0.4793,1.6.0.4905
+publicVersions=1.7.0.5143
+
+1.7.0.5143.description=Dropping Python 3.9 support and security fixes
+1.7.0.5143.date=2026-07-08
+1.7.0.5143.changelogUrl=https://sonarsource.atlassian.net/issues?jql=project%20%3D%20%22Sonar%20Scanner%20Python%22%20AND%20fixversion%20%3D%201.7.0
+1.7.0.5143.downloadUrl=https://pypi.org/project/pysonar/1.7.0.5143/
 
 1.6.0.4905.description=Automatic detection of sonar.tests property
 1.6.0.4905.date=2026-05-28


### PR DESCRIPTION
----
## Summary by Gitar

- **Version Updates:**
  - Updated `scannerpython.properties` to include `1.7.0.5143` as the latest version.
  - Moved version `1.6.0.4905` to the `archivedVersions` list.

<sub>This will update automatically on new commits.</sub>