### PR TITLE
Add ltaVersions and eolDate for 2026.1 LTA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           version: 2026.3.13
       - name: Maven Build & Validate
         run: |
-          mvn org.sonarsource.update-center:sonar-update-center-mojo:1.35.0.2835:generate-metadata \
+          mvn org.sonarsource.update-center:sonar-update-center-mojo:1.37.0.4844:generate-metadata \
             -DinputFile=update-center-source.properties \
             -DvalidateOnly=true \
             -DoutputDir=/tmp

--- a/po-generate-update-center-prod/generate.sh
+++ b/po-generate-update-center-prod/generate.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 : "${UPDATE_CENTER_PROPERTIES_FILE:=update-center-source.properties}"
 OUTPUT_DIR="$PWD/target/update-center"
 OUTPUT_DIR_ALL_VERSIONS="$PWD/target/update-center-all-versions"
-SONAR_UPDATE_CENTER_VERSION=1.35.0.2835
+SONAR_UPDATE_CENTER_VERSION=1.37.0.4844
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 pushd "${SCRIPT_DIR}/.." >/dev/null

--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -9,8 +9,7 @@ sqs=10.8,10.8.1,2025.1,2025.1.1,2025.1.2,2025.1.3,2025.1.4,2025.1.5,2025.1.6,202
 sqcb=24.12,25.1,25.2,25.3,25.4,25.5,25.6,25.7,25.8,25.9,25.10,25.11,25.12,26.1,26.2,26.3,26.4,26.5,26.6
 
 ltsVersion=2026.1.3
-ltaVersion=2026.1.3
-pastLtaVersion=2025.1.8
+ltaVersions=2025.1,2026.1
 
 2026.3.description=Embedded MCP server for AI coding agents, Sonar agentic AI quality profiles, PowerShell support, monitoring performance alerts, GitLab provisioning improvements, VEX export for Advanced Security reporting, 37 new Groovy and Jenkins pipeline rules, and many new Python rules for collections, OOP, and data structures
 2026.3.downloadUrl=https://www.sonarsource.com/products/sonarqube/downloads/?referrer=sonarqube
@@ -92,6 +91,7 @@ pastLtaVersion=2025.1.8
 2026.1.downloadDatacenterUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-2026.1.0.119033.zip
 2026.1.changelogUrl=https://docs.sonarsource.com/sonarqube-server/2026.1/server-update-and-maintenance/release-notes
 2026.1.date=2026-01-27
+2026.1.eolDate=2027-08-01
 
 26.1.description=Latest Community Build version
 26.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-26.1.0.118079.zip


### PR DESCRIPTION
This includes the eolDate/ltaVersions changes for 2026.1 LTA, and bumps the sonar-update-center-mojo version used in CI/prod generation to the latest release (1.37.0.4844).