### PR TITLE
REL-4009 SonarScanner CLI 8.1.0 update

### DIFF
--- a/scannercli.properties
+++ b/scannercli.properties
@@ -6,8 +6,8 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SCANCLI/issues
 sourcesUrl=https://github.com/Sonarsource/sonar-scanner-cli
-archivedVersions=4.1,4.2,4.3,4.4,4.5,4.6,4.6.1,4.6.2,4.7,4.8,4.8.1,5.0,5.0.1,5.0.2,6.0,6.1,6.2,6.2.1,7.0,7.0.1,7.0.2,7.1,7.2,7.3
-publicVersions=8.0.1
+archivedVersions=4.1,4.2,4.3,4.4,4.5,4.6,4.6.1,4.6.2,4.7,4.8,4.8.1,5.0,5.0.1,5.0.2,6.0,6.1,6.2,6.2.1,7.0,7.0.1,7.0.2,7.1,7.2,7.3,8.0.1
+publicVersions=8.1.0
 
 flavors=linux-x64,linux-aarch64,win,macos-x64,macos-aarch64,docker,any
 flavors.linux-x64.label=Linux x64
@@ -17,6 +17,17 @@ flavors.macos-x64.label=macOS x64
 flavors.macos-aarch64.label=macOS AArch64
 flavors.any.label=Any (Requires a pre-installed JVM)
 flavors.docker.label=Docker
+
+8.1.0.description=Fix HTTPS proxy authentication
+8.1.0.date=2026-04-21
+8.1.0.changelogUrl=https://sonarsource.atlassian.net/issues?jql=fixversion%20%3D%2027105%20ORDER%20BY%20created%20ASC
+8.1.0.downloadUrl.linux-x64=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.1.0.6389-linux-x64.zip
+8.1.0.downloadUrl.linux-aarch64=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.1.0.6389-linux-aarch64.zip
+8.1.0.downloadUrl.win=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.1.0.6389-windows-x64.zip
+8.1.0.downloadUrl.macos-x64=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.1.0.6389-macosx-x64.zip
+8.1.0.downloadUrl.macos-aarch64=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.1.0.6389-macosx-aarch64.zip
+8.1.0.downloadUrl.any=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.1.0.6389.zip
+8.1.0.downloadUrl.docker=https://hub.docker.com/r/sonarsource/sonar-scanner-cli
 
 8.0.1.description=Update embedded JREs to Java 21
 8.0.1.date=2025-12-05


### PR DESCRIPTION
----
## Summary by Gitar

- **Version update:**
    - Promoted `8.1.0` to `publicVersions` and moved `8.0.1` to `archivedVersions` in `scannercli.properties`.
- **Configuration update:**
    - Added metadata for version `8.1.0` including changelog, release date, and cross-platform `downloadUrl` artifacts.

<sub>This will update automatically on new commits.</sub>