### PR TITLE
Release SonarDelphi v1.20.0

### DIFF
--- a/communitydelphi.properties
+++ b/communitydelphi.properties
@@ -1,15 +1,23 @@
 category=Languages
 description=Code Analyzer for Delphi
 homepageUrl=https://github.com/integrated-application-development/sonar-delphi
-archivedVersions=1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.12.1,1.12.2,1.13.0,1.14.0,1.14.1,1.15.0,1.16.0,1.17.0,1.17.1,1.17.2,1.18.0,1.18.1,1.18.2,1.18.3
-publicVersions=1.19.0
+archivedVersions=1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.12.1,1.12.2,1.13.0,1.14.0,1.14.1,1.15.0,1.16.0,1.17.0,1.17.1,1.17.2,1.18.0,1.18.1,1.18.2,1.18.3,1.19.0
+publicVersions=1.20.0
 
 defaults.mavenGroupId=au.com.integradev.delphi
 defaults.mavenArtifactId=sonar-delphi-plugin
 
+1.20.0.description=Improved Delphi 13 support, support for sonar-resolve comments, type resolution improvements
+1.20.0.sqs=[10.8,LATEST]
+1.20.0.sqcb=[24.12,LATEST]
+1.20.0.sqVersions=[9.9,10.7]
+1.20.0.date=2026-08-12
+1.20.0.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.20.0
+1.20.0.downloadUrl=https://github.com/integrated-application-development/sonar-delphi/releases/download/v1.20.0/sonar-delphi-plugin-1.20.0.jar
+
 1.19.0.description=1 new rule, improved Delphi 13 support, parsing improvements, bug fixes
-1.19.0.sqs=[10.8,LATEST]
-1.19.0.sqcb=[24.12,LATEST]
+1.19.0.sqs=[10.8,2026.4.*]
+1.19.0.sqcb=[24.12,26.8.*]
 1.19.0.sqVersions=[9.9,10.7]
 1.19.0.date=2026-06-09
 1.19.0.changelogUrl=https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.19.0


### PR DESCRIPTION
SonarDelphi v1.20.0 has been released:

- [Release Notes](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.20.0)
- [SonarCloud](https://sonarcloud.io/project/overview?id=integrated-application-development_sonar-delphi)

Please add it to the marketplace.

Thanks!