### PR TITLE
sonar-l10n-zh-plugin-26.8

### DIFF
--- a/l10nzh.properties
+++ b/l10nzh.properties
@@ -2,13 +2,19 @@ category=Localization
 description=SonarQube Chinese Pack
 homepageUrl=https://github.com/SonarCommunity/sonar-l10n-zh
 archivedVersions=10.4
-publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1,25.2,25.3,25.4,25.5,25.6,25.7,25.8,25.9,25.10,25.11,25.12,26.1,26.2,26.3,26.4,26.5,26.6,26.7
+publicVersions=9.9,10.0,10.1,10.2,10.3,10.4.1,10.5,10.6,10.7,24.12,25.1,25.2,25.3,25.4,25.5,25.6,25.7,25.8,25.9,25.10,25.11,25.12,26.1,26.2,26.3,26.4,26.5,26.6,26.7,26.8
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins.l10n
 defaults.mavenArtifactId=sonar-l10n-zh-plugin
 
+26.8.description=Support SonarQube 26.8
+26.8.sqcb=[26.8,LATEST]
+26.8.date=2026-08-12
+26.8.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-26.8
+26.8.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-26.8/sonar-l10n-zh-plugin-26.8.jar
+
 26.7.description=Support SonarQube 26.7
-26.7.sqcb=[26.7,LATEST]
+26.7.sqcb=[26.7,26.7]
 26.7.date=2026-08-04
 26.7.changelogUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/tag/sonar-l10n-zh-plugin-26.7
 26.7.downloadUrl=https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-26.7/sonar-l10n-zh-plugin-26.7.jar


### PR DESCRIPTION
Hi,
sonar-l10n-zh-plugin-26.8 has been released.

The main changes is support SonarQube 26.8.

The Download link and release notes: https://github.com/xuhuisheng/sonar-l10n-zh/releases/download/sonar-l10n-zh-plugin-26.8/sonar-l10n-zh-plugin-26.8.jar

The SonarCloud: https://sonarcloud.io/project/overview?id=xuhuisheng_sonar-l10n-zh

Please update the market place.

Thank you

Regards