### PR TITLE
SONAR-31598 Add premiumEolDate and missing eolDate for LTA versions

### DIFF
--- a/update-center-source.properties
+++ b/update-center-source.properties
@@ -133,7 +133,8 @@ ltaVersions=2025.1,2026.1
 2026.1.downloadDatacenterUrl=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-2026.1.0.119033.zip
 2026.1.changelogUrl=https://docs.sonarsource.com/sonarqube-server/2026.1/server-update-and-maintenance/release-notes
 2026.1.date=2026-01-27
-2026.1.eolDate=2027-08-01
+2026.1.eolDate=2027-01-27
+2026.1.premiumEolDate=2027-08-01
 
 26.1.description=Latest Community Build version
 26.1.downloadUrl=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-26.1.0.118079.zip


### PR DESCRIPTION
## What

Adds `premiumEolDate` entries for the current LTA line (2026.1)

Part of SONAR-31638 / SONAR-31598 / MMF-5708 — Update Center supports 2 LTAs in one year.

## Date rationale

- Standard support = 12 months from initial release date.
- Premium/enterprise support = 18 months from initial release date.


## Depends on

- sonar-update-center PR #181 (adds `premiumEolDate` field to the library).