### PR TITLE
REL-4926 Update scannergradle.properties with version 7.5.0.8588

### DIFF
--- a/scannergradle.properties
+++ b/scannergradle.properties
@@ -6,12 +6,17 @@ organizationUrl=https://www.sonarsource.com
 homepageUrl=https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/
 issueTrackerUrl=https://sonarsource.atlassian.net/jira/software/c/projects/SONARGRADL/issues
 sourcesUrl=https://github.com/SonarSource/sonar-scanner-gradle
-archivedVersions=2.8,3.0,3.1,3.1.1,3.2,3.3,3.4.0.2513,3.5.0.2730,4.0.0.2929,4.2.1.3168,4.3.1.3277,4.4.1.3373,5.0.0.4638,5.1.0.4882,6.0.0.5145,6.0.1.5171,6.1.0.5360,6.2.0.5505,6.3.0.5676,6.3.1.5724,7.0.0.6105,7.0.1.6134,7.1.0.6387,7.2.0.6526,7.2.1.6560,7.2.2.6593,7.2.3.7755,7.3.0.8198,7.3.1.8318
-publicVersions=7.4.0.8496
+archivedVersions=2.8,3.0,3.1,3.1.1,3.2,3.3,3.4.0.2513,3.5.0.2730,4.0.0.2929,4.2.1.3168,4.3.1.3277,4.4.1.3373,5.0.0.4638,5.1.0.4882,6.0.0.5145,6.0.1.5171,6.1.0.5360,6.2.0.5505,6.3.0.5676,6.3.1.5724,7.0.0.6105,7.0.1.6134,7.1.0.6387,7.2.0.6526,7.2.1.6560,7.2.2.6593,7.2.3.7755,7.3.0.8198,7.3.1.8318,7.4.0.8496
+publicVersions=7.5.0.8588
+
+7.5.0.8588.description=Preserve classpath order, update BouncyCastle dependency
+7.5.0.8588.date=2026-09-02
+7.5.0.8588.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SCANGRADLE%20AND%20fixversion%20%3D%207.5
+7.5.0.8588.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube/7.5.0.8588
 
 7.4.0.8496.description=Bug fixes related to Android AGP and Android KMP projects
 7.4.0.8496.date=2026-08-06
-7.4.0.8496.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2033849%20ORDER%20BY%20created%20ASC
+7.4.0.8496.changelogUrl=https://sonarsource.atlassian.net/issues/?jql=project%20%3D%20SCANGRADLE%20AND%20fixversion%20%3D%207.4
 7.4.0.8496.downloadUrl=https://plugins.gradle.org/plugin/org.sonarqube/7.4.0.8496
 
 7.3.1.8318.description=Bug fix release about hardcoded binaries for AGP and analysis crash in the presence of task generated sources


### PR DESCRIPTION
----
## Summary by Gitar

- **Updates:**
    - Added version `7.5.0.8588` to `scannergradle.properties` with description and download URL
    - Updated `7.4.0.8496` changelog URL in `scannergradle.properties`

<sub>This will update automatically on new commits.</sub>